### PR TITLE
Crystal 0.35 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,14 +4,14 @@ version: 0.1.0
 authors:
   - Celso Fernandes <celso.fernandes@gmail.com>
 
-crystal: 0.29.0
+crystal: 0.35.0
 
 dependencies:
   schedule:
     github: hugoabonizio/schedule.cr
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.2.1
+    version: ~> 2.6.0
   habitat:
     github: luckyframework/habitat
 

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -143,7 +143,7 @@ describe Cable::Handler do
       request = HTTP::Request.new("GET", "/unknown_route?test_token=1", headers)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
-      io_with_context.to_s.should eq("")
+      io_with_context.to_s.should contain("404 Not Found")
     end
 
     it "doesn't upgrade with wrong headers (without Upgrade header)" do
@@ -153,7 +153,7 @@ describe Cable::Handler do
       request = HTTP::Request.new("GET", "/unknown_route?test_token=1", headers_without_upgrade)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
-      io_with_context.to_s.should eq("")
+      io_with_context.to_s.should contain("404 Not Found")
     end
 
     it "doesn't upgrade with wrong headers (without Connection header)" do
@@ -163,7 +163,7 @@ describe Cable::Handler do
       request = HTTP::Request.new("GET", "/unknown_route?test_token=1", headers_without_connection)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
-      io_with_context.to_s.should eq("")
+      io_with_context.to_s.should contain("404 Not Found")
     end
   end
 end

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -7,7 +7,7 @@ describe Cable::Handler do
       request = HTTP::Request.new("GET", "#{Cable.settings.route}?test_token=1", headers)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
-      io_with_context.to_s.should eq("HTTP/1.1 101 Switching Protocols\r\nSec-WebSocket-Protocol: actioncable-v1-json\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: 6x90CSU0y750nc+5Do8J0YjG7lM=\r\n\r\n\x81\u0012{\"type\":\"welcome\"}")
+      io_with_context.to_s.should eq("HTTP/1.1 101 Switching Protocols\r\nSec-WebSocket-Protocol: actioncable-v1-json\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: 6x90CSU0y750nc+5Do8J0YjG7lM=\r\n\r\n")
     end
 
     it "starts the web pinger" do

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -71,7 +71,7 @@ module Cable
       begin
         connect
       rescue e : UnathorizedConnectionException
-        socket.close
+        socket.close(HTTP::WebSocket::CloseCode::NormalClosure, "Farewell")
         Cable::Logger.info("An unauthorized connection attempt was rejected")
       end
     end

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -20,11 +20,11 @@ module Cable
 
     macro identified_by(name)
       @{{name.id}} : String = ""
-      
+
       def {{name.id}}=(value : String)
         @{{name.id}} = value
       end
-    
+
       def {{name.id}}
         @{{name.id}}
       end
@@ -36,7 +36,7 @@ module Cable
 
     macro owned_by(type_definition)
       @{{type_definition.var}} : {{type_definition.type}}?
-      
+
       def {{type_definition.var}}=(value : {{type_definition.type}})
         @{{type_definition.var}} = value
       end

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -22,7 +22,7 @@ module Cable
         connection = @connection_class.new(context.request, socket)
 
         # Send welcome message to the client
-        socket.send ({type: "welcome"}.to_json)
+        socket.send({type: "welcome"}.to_json)
 
         Cable::WebsocketPinger.build(socket)
 
@@ -43,6 +43,7 @@ module Cable
 
       Cable::Logger.info "Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)"
       content = ws.call(context)
+      content.as(Proc(IO, Nil)).call(context.response.output)
       context.response.print(content)
       context
     end

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -14,7 +14,7 @@ module Cable
 
       remote_address = context.request.remote_address
       path = context.request.path
-      Cable::Logger.info "Started GET \"#{path}\" [WebSocket] for #{remote_address} at #{Time.now.to_s}"
+      Cable::Logger.info "Started GET \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
 
       context.response.headers["Sec-WebSocket-Protocol"] = "actioncable-v1-json"
 
@@ -37,7 +37,7 @@ module Cable
 
         socket.on_close do
           connection.close
-          Cable::Logger.info "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.now.to_s}"
+          Cable::Logger.info "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
         end
       end
 

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -26,6 +26,10 @@ module Cable
 
         Cable::WebsocketPinger.build(socket)
 
+        socket.on_ping do
+          socket.pong context.request.path
+        end
+
         # Handle incoming message and echo back to the client
         socket.on_message do |message|
           begin
@@ -42,10 +46,7 @@ module Cable
       end
 
       Cable::Logger.info "Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)"
-      content = ws.call(context)
-      content.as(Proc(IO, Nil)).call(context.response.output)
-      context.response.print(content)
-      context
+      ws.call(context)
     end
 
     private def websocket_upgrade_request?(context)

--- a/src/cable/logger.cr
+++ b/src/cable/logger.cr
@@ -1,10 +1,10 @@
-require "logger"
+require "log"
 
 module Cable
   class Logger
     @@show : Bool = true
     @@messages = [] of String
-    LOG = ::Logger.new(STDOUT)
+    LOG = ::Log.for("cable")
 
     def self.suppress_output
       @@show = false
@@ -15,7 +15,7 @@ module Cable
     end
 
     def self.info(message)
-      return Cable::Logger::LOG.info message if @@show
+      return Cable::Logger::LOG.info { message } if @@show
       @@messages << message
     end
 


### PR DESCRIPTION
Fixes #2 

This PR lets the shard compile on Crystal 0.35. However, there's still a few issues to sort out.

* [x] - Specs fail locally (and on the CI apparently)
* [x] - The logger needs to be refactored to support the new logger
* [ ] - ....
* [ ] - Profit!