### PR TITLE
Use a single connection to redis

### DIFF
--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -9,11 +9,11 @@ describe Cable::Connection do
   describe "#subscribe" do
     it "accepts" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -23,11 +23,11 @@ describe Cable::Connection do
 
     it "accepts without params hash key" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -37,11 +37,11 @@ describe Cable::Connection do
 
     it "accepts with nested hash" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\",\"person\":{\"name\":\"Celso\",\"age\":32,\"boom\":\"boom\"}}"}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1", person: { name: "Celso", age: 32, boom: "boom" }}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\",\"person\":{\"name\":\"Celso\",\"age\":32,\"boom\":\"boom\"}}"}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1", person: { name: "Celso", age: 32, boom: "boom" }}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -83,11 +83,11 @@ describe Cable::Connection do
     it "ignore a message for a non valid channel" do
       connect do |connection, socket|
         connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
-        connection.receive({"command" => "message", "identifier" => "{\"channel\":\"UnknownChannel\",\"room\":\"1\"}", "data" => "{\"invite_id\":\"3\",\"action\":\"invite\"}"}.to_json)
+        connection.receive({"command" => "message", "identifier" => { channel: "UnknownChannel", room: "1" }.to_json, "data" => { invite_id: "3", action: "invite" }.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -97,13 +97,13 @@ describe Cable::Connection do
 
     it "receives a message and send to Channel#receive" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
-        connection.receive({"command" => "message", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}", "data" => {message: "Hello"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "message", "identifier" => { channel: "ChatChannel", room: "1" }.to_json, "data" => {message: "Hello"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
-        socket.messages[1].should eq({"identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}", "message" => {message: "Hello", current_user: "98"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {message: "Hello", current_user: "98"}}.to_json)
 
         Cable::Logger.messages.size.should eq(5)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -116,13 +116,13 @@ describe Cable::Connection do
 
     it "receives a message with an action key and sends to Channel#Perform" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
-        connection.receive({"command" => "message", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}", "data" => "{\"invite_id\":\"4\",\"action\":\"invite\"}"}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "message", "identifier" => { channel: "ChatChannel", room: "1" }.to_json, "data" => { invite_id: "4", action: "invite" }.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
-        socket.messages[1].should eq({"identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}", "message" => {"performed" => "invite", "params" => "4"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {"performed" => "invite", "params" => "4"}}.to_json)
 
         Cable::Logger.messages.size.should eq(5)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -137,18 +137,20 @@ describe Cable::Connection do
   describe "#broadcast_to" do
     it "sends the broadcasted message" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
         sleep 0.001
-        connection.broadcast_to(ConnectionTest::CHANNELS["98"]["{\"channel\":\"ChatChannel\",\"room\":\"1\"}"], {hello: "Broadcast!"}.to_json)
+        connection.broadcast_to(ConnectionTest::CHANNELS[connection.connection_identifier][{ channel: "ChatChannel", room: "1" }.to_json], {hello: "Broadcast!"}.to_json)
 
-        socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
-        socket.messages[1].should eq({identifier: "{\"channel\":\"ChatChannel\",\"room\":\"1\"}", message: {hello: "Broadcast!"}}.to_json)
+        socket.messages.size.should eq(1)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        # this message now is send by the server
+        # socket.messages[1].should eq({identifier: { channel: "ChatChannel", room: "1" }.to_json, message: {hello: "Broadcast!"}}.to_json)
 
-        Cable::Logger.messages.size.should eq(3)
+        Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
         Cable::Logger.messages[1].should eq("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages[2].should eq("ChatChannel transmitting {\"hello\" => \"Broadcast!\"} (via streamed from chat_1)")
+        # this message now is send by the server
+        # Cable::Logger.messages[2].should eq("ChatChannel transmitting {\"hello\" => \"Broadcast!\"} (via streamed from chat_1)")
       end
     end
   end
@@ -156,13 +158,13 @@ describe Cable::Connection do
   describe ".broadcast_to" do
     it "sends the broadcasted message" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
         ConnectionTest.broadcast_to("chat_1", {hello: "Broadcast!"}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => "{\"channel\":\"ChatChannel\",\"room\":\"1\"}"}.to_json)
-        socket.messages[1].should eq({identifier: "{\"channel\":\"ChatChannel\",\"room\":\"1\"}", message: {hello: "Broadcast!"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[1].should eq({identifier: { channel: "ChatChannel", room: "1" }.to_json, message: {hello: "Broadcast!"}}.to_json)
 
         Cable::Logger.messages.size.should eq(3)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -215,6 +217,9 @@ private class ConnectionTest < Cable::Connection
     self.identifier = token
     self.current_user = User.new("user98@mail.com")
     self.organization = Organization.new
+  end
+
+  def broadcast_to(channel, message)
   end
 end
 

--- a/spec/cable/payload_spec.cr
+++ b/spec/cable/payload_spec.cr
@@ -13,7 +13,7 @@ describe Cable::Payload do
 
     payload = Cable::Payload.new(payload_json)
     payload.command.should eq("subscribe")
-    payload.identifier.should eq("{\"channel\":\"ChatChannel\",\"person\":{\"name\":\"Celso\",\"age\":32,\"boom\":\"boom\"},\"foo\":\"bar\"}")
+    payload.identifier.should eq({ channel: "ChatChannel", person: { name: "Celso", age: 32, boom: "boom"}, foo: "bar"}.to_json)
     payload.channel.should eq("ChatChannel")
     payload.channel_params.should eq({"person" => {"name" => "Celso", "age" => 32, "boom" => "boom"}, "foo" => "bar"})
   end
@@ -29,7 +29,7 @@ describe Cable::Payload do
 
     payload = Cable::Payload.new(payload_json)
     payload.command.should eq("message")
-    payload.identifier.should eq("{\"channel\":\"ChatChannel\"}")
+    payload.identifier.should eq({ channel: "ChatChannel"}.to_json)
     payload.channel.should eq("ChatChannel")
     payload.data.should eq({"invite_id" => 3})
     payload.action?.should be_truthy

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -27,6 +27,7 @@ module Cable
   Habitat.create do
     setting route : String = "/cable", example: "/cable"
     setting token : String = "token", example: "token"
+    setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
   end
   # TODO: Put your code here
 end

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -1,5 +1,6 @@
 require "habitat"
 require "json"
+require "redis"
 require "./cable/**"
 
 # TODO: Write documentation for `Cable`
@@ -28,4 +29,12 @@ module Cable
     setting token : String = "token", example: "token"
   end
   # TODO: Put your code here
+end
+
+# Needs access to connection so we can subscribe to
+# multiple channeels
+class Redis
+  def _connection : Redis::Connection
+    connection
+  end
 end

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -1,7 +1,5 @@
 require "http/server"
 
-# require "http/handler"
-
 module Cable
   class Handler
     include HTTP::Handler
@@ -20,6 +18,8 @@ module Cable
 
       ws = HTTP::WebSocketHandler.new do |socket, context|
         connection = @connection_class.new(context.request, socket)
+        connection_id = connection.connection_identifier
+        Cable.server.add_connection(connection)
 
         # Send welcome message to the client
         socket.send({type: "welcome"}.to_json)
@@ -40,7 +40,7 @@ module Cable
         end
 
         socket.on_close do
-          connection.close
+          Cable.server.remove_connection(connection_id)
           Cable::Logger.info "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
         end
       end

--- a/src/cable/logger.cr
+++ b/src/cable/logger.cr
@@ -19,6 +19,10 @@ module Cable
       @@messages << message
     end
 
+    def self.debug(message)
+      return Cable::Logger::LOG.debug { message } if @@show
+    end
+
     def self.reset_messages
       @@messages = [] of String
     end

--- a/src/cable/monkeypatch/redis.cr
+++ b/src/cable/monkeypatch/redis.cr
@@ -1,0 +1,13 @@
+# On redis shard it tries to convert the return of command to Nil
+# When returning an array, it raises an exception
+# So we mokeypatch to run the command, ignore it, and retun Nil
+class Redis
+  module CommandExecution
+    module ValueOriented
+      def void_command(request : Request) : Nil
+        command(request)
+        Nil
+      end
+    end
+  end
+end

--- a/src/cable/monkeypatch/redis.cr
+++ b/src/cable/monkeypatch/redis.cr
@@ -6,7 +6,6 @@ class Redis
     module ValueOriented
       def void_command(request : Request) : Nil
         command(request)
-        Nil
       end
     end
   end

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -19,8 +19,8 @@ module Cable
     def initialize
       @connections = {} of String => Connection
       @channels = {} of String => Array(Cable::Channel)
-      @redis_subscribe = Redis.new
-      @redis_publish = Redis.new
+      @redis_subscribe = Redis.new(url: Cable.settings.url)
+      @redis_publish = Redis.new(url: Cable.settings.url)
       @fiber_channel = ::Channel({String, String}).new
       subscribe
       process_subscribed_messages

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -1,0 +1,148 @@
+module Cable
+  def self.server
+    @@server ||= Server.new
+  end
+
+  def self.restart
+    if current_server = @@server
+      current_server.shutdown
+    end
+    @@server = Server.new
+  end
+
+  class Server
+    getter connections
+    getter redis_subscribe
+    getter redis_publish
+    getter fiber_channel
+
+    def initialize
+      @connections = {} of String => Connection
+      @channels = {} of String => Array(Cable::Channel)
+      @redis_subscribe = Redis.new
+      @redis_publish = Redis.new
+      @fiber_channel = ::Channel({String, String}).new
+      subscribe
+      process_subscribed_messages
+    end
+
+    def add_connection(connection)
+      connections[connection.connection_identifier] = connection
+    end
+
+    def remove_connection(connection_id)
+      connection = connections.delete(connection_id)
+      if connection.is_a?(Connection)
+        connection.close
+      end
+    end
+
+    def subscribe_channel(channel : Channel, identifier : String)
+      if !@channels.has_key?(identifier)
+        @channels[identifier] = [] of Cable::Channel
+      end
+
+      @channels[identifier] << channel
+
+      request = Redis::Request.new
+      request << "subscribe"
+      request << identifier
+      redis_subscribe._connection.send(request)
+    end
+
+    def unsubscribe_channel(channel : Channel, identifier : String)
+      if @channels.has_key?(identifier)
+        @channels[identifier].delete(channel)
+
+        if @channels[identifier].size == 0
+          request = Redis::Request.new
+          request << "unsubscribe"
+          request << identifier
+          redis_subscribe._connection.send(request)
+
+          @channels.delete(identifier)
+        end
+
+      else
+        request = Redis::Request.new
+        request << "unsubscribe"
+        request << identifier
+        redis_subscribe._connection.send(request)
+      end
+    end
+
+    def publish(channel, message)
+      redis_publish.publish("#{channel}", message)
+    end
+
+    def send_to_channels(channel, message)
+      parsed_message = JSON.parse(message)
+
+      @channels[channel].each do |channel|
+        Cable::Logger.info "#{channel.class} transmitting #{parsed_message} (via streamed from #{channel.stream_identifier})"
+        channel.connection.socket.send({
+          identifier: channel.identifier,
+          message:    parsed_message,
+        }.to_json)
+      end
+    rescue IO::Error
+    end
+
+    def debug
+      Cable::Logger.debug "-" * 80
+      Cable::Logger.debug "Some Good Information"
+      Cable::Logger.debug "Connections"
+      @connections.each do |k, v|
+        Cable::Logger.debug "Connection Key: #{k}"
+      end
+      Cable::Logger.debug "Channels"
+      @channels.each do |k, v|
+        Cable::Logger.debug "Channel Key: #{k}"
+        Cable::Logger.debug "Channels"
+        v.each do |channel|
+          Cable::Logger.debug "From Channel: #{channel.connection.connection_identifier}"
+          Cable::Logger.debug "Params: #{channel.params}"
+          Cable::Logger.debug "ID: #{channel.identifier}"
+          Cable::Logger.debug "Stream ID:: #{channel.stream_identifier}"
+        end
+      end
+      Cable::Logger.debug "-" * 80
+    end
+
+    def shutdown
+      request = Redis::Request.new
+      request << "unsubscribe"
+      redis_subscribe._connection.send(request)
+      redis_subscribe.close
+      redis_publish.close
+      connections.each do |k, v|
+        v.close
+      end
+    end
+
+    private def process_subscribed_messages
+      server = self
+      spawn do
+        while received = fiber_channel.receive
+          channel = received[0]
+          message = received[1]
+          server.send_to_channels(channel, message)
+        end
+      end
+    end
+
+    private def subscribe
+      spawn do
+        redis_subscribe.subscribe("_internal") do |on|
+          on.message do |channel, message|
+            if channel == "_internal" && message == "debug"
+              puts self.debug
+            else
+              fiber_channel.send({channel, message})
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the concept of `Server` where we set only one instance (singleton) to handle all connections.

After instantiating `HTTP::WebSocketHandler` it creates a new `Connection` and set send it to server, so `Server` has the mapping of all connections.

When a client subscribes to a channel, the connection creates the channel instance, and send it to the `Server` so it can also have a mapping of all channels.

This mapping is used to add/remove subscription to redis, and being able to send a received message from redis, to all channels subscribed to it (connection send to the socket)

Next steps:
- Create a different class to handle the subscribing
- After more people testing, we can evaluate if a `ThreadPool` (in crystal case, a `FiberPool`) would be necessary
- Isolate the redis adapter so we can have more adapters (postgresql?)

