### PR TITLE
Initial idea for a non-required auth token

### DIFF
--- a/spec/support/application_cable/connection.cr
+++ b/spec/support/application_cable/connection.cr
@@ -3,7 +3,9 @@ module ApplicationCable
     identified_by :identifier
 
     def connect
-      self.identifier = token
+      if tk = token
+        self.identifier = tk
+      end
     end
   end
 end

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -7,7 +7,7 @@ module Cable
     @@mock : Cable::Connection?
 
     property internal_identifier : String = "0"
-    getter token : String
+    getter token : String?
     getter connection_identifier : String
 
     CHANNELS = {} of String => Hash(String, Cable::Channel)
@@ -64,9 +64,7 @@ module Cable
     end
 
     def initialize(@request : HTTP::Request, @socket : HTTP::WebSocket)
-      @token = @request.query_params.fetch(Cable.settings.token) {
-        raise "No token on params"
-      }
+      @token = @request.query_params.fetch(Cable.settings.token, nil)
       @id = UUID.random.to_s
       @connection_identifier = ""
 


### PR DESCRIPTION
Closes #6

If you guys could please check this branch if it works correctly @jwoertink @jgaskins @confact

⚠️ This is totally untested code, I just had this idea and wanted to get your feedback before digging into it ⚠️ 

I'm not that used to this "non-authenticated" use case, I see a lot of value with the hotwire thing, just haven't played, I see that we don't need a token to authenticated, but in the other hand we need a unique identifier for the connection, so what I'm doing is, if there is no token / or user, we generate a UUID as identifier

Now that `token` is `String?` we need to check it on the connect method

```crystal
    if tk = token
      self.identifier = tk
    end
```

what's not a big deal

Instead of trying to do a lot of magic inside cable code, I think a good solution can be give the instructions to handle the UUID on the app code, so we can have different approaches to this problem

### Auth with Token

```crystal
Connection < Cable::Connection
  identified_by :identifier
  owned_by current_user : User
  owned_by organization : Organization

  def connect
    if tk = token
      self.identifier = tk
    end
    self.current_user = User.new("user98@mail.com")
    self.organization = Organization.new
  end
end
```

### Unauthenticated

```crystal
class Connection < Cable::Connection
  identified_by :uuid

  def connect
    self.uuid = UUID.random.to_s
  end
end
```

### Mixed Approach (untested)

```crystal
class Connection < Cable::Connection
  identified_by :identifier

  def connect
    if tk = token
      self.identifier = tk
    else
      self.identifier = UUID.random.to_s
    end
  end
end
```