### PR TITLE
support for string in message

### DIFF
--- a/spec/cable/payload_spec.cr
+++ b/spec/cable/payload_spec.cr
@@ -6,16 +6,16 @@ describe Cable::Payload do
       command:    "subscribe",
       identifier: {
         channel: "ChatChannel",
-        person:  {name: "Celso", age: 32, boom: "boom"},
+        person:  {name: "Foo", age: 32, boom: "boom"},
         foo:     "bar",
       }.to_json,
     }.to_json
 
     payload = Cable::Payload.new(payload_json)
     payload.command.should eq("subscribe")
-    payload.identifier.should eq({ channel: "ChatChannel", person: { name: "Celso", age: 32, boom: "boom"}, foo: "bar"}.to_json)
+    payload.identifier.should eq({ channel: "ChatChannel", person: { name: "Foo", age: 32, boom: "boom"}, foo: "bar"}.to_json)
     payload.channel.should eq("ChatChannel")
-    payload.channel_params.should eq({"person" => {"name" => "Celso", "age" => 32, "boom" => "boom"}, "foo" => "bar"})
+    payload.channel_params.should eq({"person" => {"name" => "Foo", "age" => 32, "boom" => "boom"}, "foo" => "bar"})
   end
 
   it "parses a perform command" do

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -50,7 +50,7 @@ module Cable
 
     def self.broadcast_to(channel : String, message : String)
       Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
-      Cable.server.publish("#{channel}", message)
+      Cable.server.publish("#{channel}", message.to_json)
     end
 
     def self.broadcast_to(channel : String, message : Hash(String, String))

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -48,6 +48,11 @@ module Cable
       Cable.server.publish("#{channel}", message.to_json)
     end
 
+    def self.broadcast_to(channel : String, message : String)
+      Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
+      Cable.server.publish("#{channel}", message.to_json)
+    end
+
     def self.broadcast_to(channel : String, message : Hash(String, String))
       Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
       Cable.server.publish("#{channel}", message.to_json)

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -50,7 +50,7 @@ module Cable
 
     def self.broadcast_to(channel : String, message : String)
       Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
-      Cable.server.publish("#{channel}", message.to_json)
+      Cable.server.publish("#{channel}", message)
     end
 
     def self.broadcast_to(channel : String, message : Hash(String, String))


### PR DESCRIPTION
Added a method for a string as a message. Now the only types that is accepted are JSON::Any and Hash(String, String) - That would make Turbo not work or have to make a string to JSON::Any first.

I first tried to send a hash with the turbo data:
```
{
 "identifier": {.....},
 "message": { "turbo": "<turbo-stream>..." }
}
```
but turbo wants it to look like this:
```
{
 "identifier": {.....},
 "message": "<turbo-stream>..."
}
```

With this method, it solves it in a nicer way to skip make a string to JSON to get the type JSON::Any.