### PR TITLE
Implement reject on Cable::Channel

### DIFF
--- a/spec/support/channels/rejection_channel.cr
+++ b/spec/support/channels/rejection_channel.cr
@@ -1,0 +1,22 @@
+class RejectionChannel < ApplicationCable::Channel
+  def subscribed
+    # We don't support stream_for, needs to generate your own unique string
+    stream_from "rejection"
+    reject # we are rejecting any connection here
+  end
+
+  def receive(message)
+    broadcast_message = {} of String => String
+    if message.is_a?(String)
+      broadcast_message["message"] = message
+    else
+      broadcast_message["message"] = message["message"].to_s
+    end
+    broadcast_message["current_user"] = connection.identifier
+    RejectionChannel.broadcast_to("rejection", broadcast_message)
+  end
+
+  def unsubscribed
+    # You can do any action after channel is unsubscribed
+  end
+end

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -13,7 +13,15 @@ module Cable
     getter connection
     getter stream_identifier : String?
 
-    def initialize(@connection : Cable::Connection, @identifier : String, @params : Hash(String, Cable::Payload::RESULT))
+    def initialize(@connection : Cable::Connection, @identifier : String, @params : Hash(String, Cable::Payload::RESULT), @reject_subscription : Bool = false)
+    end
+
+    def reject
+      @reject_subscription = true
+    end
+
+    def subscription_rejected?
+      @reject_subscription
     end
 
     def subscribed
@@ -39,8 +47,6 @@ module Cable
 
     def stream_from(stream_identifier)
       @stream_identifier = stream_identifier
-      Cable.server.subscribe_channel(channel: self, identifier: stream_identifier)
-      Cable::Logger.info "#{self.class.to_s} is streaming from #{stream_identifier}"
     end
 
     def self.broadcast_to(channel : String, message : JSON::Any)

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -112,17 +112,15 @@ module Cable
       Connection::CHANNELS[connection_identifier][payload.identifier] = channel
       channel.subscribed
 
-      if channel.subscription_rejected?
-        reject(channel)
-      else
-        if stream_identifier = channel.stream_identifier
-          Cable.server.subscribe_channel(channel: channel, identifier: stream_identifier)
-          Cable::Logger.info "#{channel.class.to_s} is streaming from #{stream_identifier}"
-        end
-
-        Cable::Logger.info "#{payload.channel} is transmitting the subscription confirmation"
-        socket.send({type: "confirm_subscription", identifier: payload.identifier}.to_json)
+      return reject(channel) if channel.subscription_rejected?
+        
+      if stream_identifier = channel.stream_identifier
+        Cable.server.subscribe_channel(channel: channel, identifier: stream_identifier)
+        Cable::Logger.info "#{channel.class.to_s} is streaming from #{stream_identifier}"
       end
+
+      Cable::Logger.info "#{payload.channel} is transmitting the subscription confirmation"
+      socket.send({type: "confirm_subscription", identifier: payload.identifier}.to_json)
     end
 
     def unsubscribe(payload : Cable::Payload)


### PR DESCRIPTION
This PR implement `reject` on Cable::Channel, it implied in a little refactor on the subscription method to keep the API closest as possible to rails one

There is a `RejectionChannel` on the spec, but the idea is

```crystal
class RejectionChannel < ApplicationCable::Channel
  def subscribed
    stream_from "rejection" # here we can set anything to the identifier
    reject # we are rejecting any connection here
    # we can also use any condition based on you app's model
    # reject unless current_user.admin?
  end
end
```

This PR is to make our one and only @confact happy 🍻 😄 

Closes #17