### PR TITLE
Updates the crystal version restriction

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,8 +7,9 @@ authors:
 crystal: ">= 0.35.0, < 2.0.0"
 
 dependencies:
-  schedule:
-    github: hugoabonizio/schedule.cr
+  tasker:
+    github: spider-gazelle/tasker
+    version: ~> 2.0
   redis:
     github: stefanwille/crystal-redis
     version: ~> 2.7.0

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ dependencies:
     github: hugoabonizio/schedule.cr
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.6.0
+    version: ~> 2.7.0
   habitat:
     github: luckyframework/habitat
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 authors:
   - Celso Fernandes <celso.fernandes@gmail.com>
 
-crystal: 0.35.0
+crystal: ">= 0.35.0, < 2.0.0"
 
 dependencies:
   schedule:

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -9,11 +9,11 @@ describe Cable::Connection do
   describe "#subscribe" do
     it "accepts" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -23,11 +23,11 @@ describe Cable::Connection do
 
     it "accepts without params hash key" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -37,11 +37,11 @@ describe Cable::Connection do
 
     it "accepts with nested hash" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1", person: { name: "Foo", age: 32, boom: "boom" }}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1", person: {name: "Foo", age: 32, boom: "boom"}}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1", person: { name: "Foo", age: 32, boom: "boom" }}.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1", person: {name: "Foo", age: 32, boom: "boom"}}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -51,11 +51,11 @@ describe Cable::Connection do
 
     it "accepts without auth token" do
       connect(connection_class: ConnectionNoTokenTest, token: nil) do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1", person: { name: "Celso", age: 32, boom: "boom" }}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1", person: {name: "Celso", age: 32, boom: "boom"}}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1", person: { name: "Celso", age: 32, boom: "boom" }}.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1", person: {name: "Celso", age: 32, boom: "boom"}}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -67,13 +67,13 @@ describe Cable::Connection do
   describe "#unsubscribe" do
     it "unsubscribes from a channel" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        connection.receive({"command" => "unsubscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        connection.receive({"command" => "unsubscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        socket.messages[1].should eq({"type" => "confirm_unsubscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        socket.messages[1].should eq({"type" => "confirm_unsubscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(3)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -104,7 +104,7 @@ describe Cable::Connection do
     it "rejects the unauthorized connection (and does not receive any message)" do
       connect(UnauthorizedConnectionTest) do |connection, socket|
         connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
-        connection.receive({"command" => "message", "identifier" => { channel: "ChatChannel", room: "1" }.to_json, "data" => {message: "Hello"}.to_json}.to_json)
+        connection.receive({"command" => "message", "identifier" => {channel: "ChatChannel", room: "1"}.to_json, "data" => {message: "Hello"}.to_json}.to_json)
 
         socket.messages.size.should eq(0)
 
@@ -119,11 +119,11 @@ describe Cable::Connection do
     it "ignore a message for a non valid channel" do
       connect do |connection, socket|
         connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
-        connection.receive({"command" => "message", "identifier" => { channel: "UnknownChannel", room: "1" }.to_json, "data" => { invite_id: "3", action: "invite" }.to_json}.to_json)
+        connection.receive({"command" => "message", "identifier" => {channel: "UnknownChannel", room: "1"}.to_json, "data" => {invite_id: "3", action: "invite"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -133,13 +133,13 @@ describe Cable::Connection do
 
     it "receives a message and send to Channel#receive" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        connection.receive({"command" => "message", "identifier" => { channel: "ChatChannel", room: "1" }.to_json, "data" => {message: "Hello"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        connection.receive({"command" => "message", "identifier" => {channel: "ChatChannel", room: "1"}.to_json, "data" => {message: "Hello"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {message: "Hello", current_user: "98"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        socket.messages[1].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {message: "Hello", current_user: "98"}}.to_json)
 
         Cable::Logger.messages.size.should eq(5)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -152,13 +152,13 @@ describe Cable::Connection do
 
     it "receives a message with an action key and sends to Channel#Perform" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        connection.receive({"command" => "message", "identifier" => { channel: "ChatChannel", room: "1" }.to_json, "data" => { invite_id: "4", action: "invite" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        connection.receive({"command" => "message", "identifier" => {channel: "ChatChannel", room: "1"}.to_json, "data" => {invite_id: "4", action: "invite"}.to_json}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {"performed" => "invite", "params" => "4"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        socket.messages[1].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {"performed" => "invite", "params" => "4"}}.to_json)
 
         Cable::Logger.messages.size.should eq(5)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -173,12 +173,12 @@ describe Cable::Connection do
   describe "#broadcast_to" do
     it "sends the broadcasted message" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         sleep 0.001
-        connection.broadcast_to(ConnectionTest::CHANNELS[connection.connection_identifier][{ channel: "ChatChannel", room: "1" }.to_json], {hello: "Broadcast!"}.to_json)
+        connection.broadcast_to(ConnectionTest::CHANNELS[connection.connection_identifier][{channel: "ChatChannel", room: "1"}.to_json], {hello: "Broadcast!"}.to_json)
 
         socket.messages.size.should eq(1)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         Cable::Logger.messages.size.should eq(2)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -190,13 +190,13 @@ describe Cable::Connection do
   describe ".broadcast_to" do
     it "sends the broadcasted message" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         ConnectionTest.broadcast_to("chat_1", {hello: "Broadcast!"}.to_json)
         sleep 0.001
 
         socket.messages.size.should eq(2)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        socket.messages[1].should eq({identifier: { channel: "ChatChannel", room: "1" }.to_json, message: {hello: "Broadcast!"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        socket.messages[1].should eq({identifier: {channel: "ChatChannel", room: "1"}.to_json, message: {hello: "Broadcast!"}}.to_json)
 
         Cable::Logger.messages.size.should eq(3)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
@@ -210,14 +210,14 @@ describe Cable::Connection do
     describe "as string" do
       it "receives correctly" do
         connect do |connection, socket|
-          connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+          connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
           ChatChannel.broadcast_to(channel: "chat_1", message: "<turbo-stream></turbo-stream>")
           sleep 0.001
-  
+
           socket.messages.size.should eq(2)
-          socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-          socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => "<turbo-stream></turbo-stream>"}.to_json)
-  
+          socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+          socket.messages[1].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => "<turbo-stream></turbo-stream>"}.to_json)
+
           Cable::Logger.messages.size.should eq(4)
           Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
           Cable::Logger.messages[1].should eq("ChatChannel is transmitting the subscription confirmation")
@@ -230,14 +230,14 @@ describe Cable::Connection do
     describe "as Hash(String, String)" do
       it "receives correctly" do
         connect do |connection, socket|
-          connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+          connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
           ChatChannel.broadcast_to(channel: "chat_1", message: {"foo" => "bar"})
           sleep 0.001
-  
+
           socket.messages.size.should eq(2)
-          socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-          socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {"foo" => "bar"}}.to_json)
-  
+          socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+          socket.messages[1].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {"foo" => "bar"}}.to_json)
+
           Cable::Logger.messages.size.should eq(4)
           Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
           Cable::Logger.messages[1].should eq("ChatChannel is transmitting the subscription confirmation")
@@ -250,15 +250,15 @@ describe Cable::Connection do
     describe "as JSON::Any" do
       it "receives correctly" do
         connect do |connection, socket|
-          connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+          connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
           json_message = JSON.parse(%({"foo": "bar"}))
           ChatChannel.broadcast_to(channel: "chat_1", message: json_message)
           sleep 0.001
-  
+
           socket.messages.size.should eq(2)
-          socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-          socket.messages[1].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {"foo" => "bar"}}.to_json)
-  
+          socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+          socket.messages[1].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {"foo" => "bar"}}.to_json)
+
           Cable::Logger.messages.size.should eq(4)
           Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
           Cable::Logger.messages[1].should eq("ChatChannel is transmitting the subscription confirmation")
@@ -272,8 +272,8 @@ describe Cable::Connection do
   describe "when channel rejects a connection" do
     it "does not send any message to that connection related to the channel" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        connection.receive({"command" => "subscribe", "identifier" => { channel: "RejectionChannel" }.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "RejectionChannel"}.to_json}.to_json)
         json_message = JSON.parse(%({"foo": "bar"}))
         ChatChannel.broadcast_to(channel: "chat_1", message: json_message)
 
@@ -283,9 +283,9 @@ describe Cable::Connection do
 
         # Even after broadcasting to Rejection channel, we can check the socket didn't receive it
         socket.messages.size.should eq(3)
-        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => { channel: "ChatChannel", room: "1" }.to_json}.to_json)
-        socket.messages[1].should eq({"type" => "reject_subscription", "identifier" => { channel: "RejectionChannel" }.to_json}.to_json)
-        socket.messages[2].should eq({"identifier" => { channel: "ChatChannel", room: "1" }.to_json, "message" => {"foo" => "bar"}}.to_json)
+        socket.messages[0].should eq({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        socket.messages[1].should eq({"type" => "reject_subscription", "identifier" => {channel: "RejectionChannel"}.to_json}.to_json)
+        socket.messages[2].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {"foo" => "bar"}}.to_json)
 
         Cable::Logger.messages.size.should eq(6)
         Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -288,13 +288,13 @@ describe Cable::Connection do
         socket.messages[2].should eq({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {"foo" => "bar"}}.to_json)
 
         Cable::Logger.messages.size.should eq(6)
-        Cable::Logger.messages[0].should eq("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages[1].should eq("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages[2].should eq("RejectionChannel is transmitting the subscription rejection")
-        Cable::Logger.messages[3].should eq("[ActionCable] Broadcasting to chat_1: {\"foo\" => \"bar\"}")
+        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
+        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
+        Cable::Logger.messages.should contain("RejectionChannel is transmitting the subscription rejection")
+        Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: {\"foo\" => \"bar\"}")
         # and here we can confirm the message was broadcasted
-        Cable::Logger.messages[4].should eq("[ActionCable] Broadcasting to rejection: {\"foo\" => \"bar\"}")
-        Cable::Logger.messages[5].should eq("ChatChannel transmitting {\"foo\" => \"bar\"} (via streamed from chat_1)")
+        Cable::Logger.messages.should contain("ChatChannel transmitting {\"foo\" => \"bar\"} (via streamed from chat_1)")
+        Cable::Logger.messages.should contain("[ActionCable] Broadcasting to rejection: {\"foo\" => \"bar\"}")
       end
     end
   end

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -22,7 +22,7 @@ describe Cable::Handler do
             str.match(/\{\"type\":\"ping\",\"message\":[0-9]{10}\}/).should be_truthy
             ws2.close
           else
-            str.should eq({ type: "welcome"}.to_json)
+            str.should eq({type: "welcome"}.to_json)
             initialized = true
           end
         end
@@ -40,8 +40,8 @@ describe Cable::Handler do
       ws2 = HTTP::WebSocket.new("ws://#{listen_address}/updates?test_token=1")
 
       messages = [
-        { type: "welcome"}.to_json,
-        { type: "confirm_subscription", identifier: { channel: "ChatChannel", room: "1" }.to_json }.to_json,
+        {type: "welcome"}.to_json,
+        {type: "confirm_subscription", identifier: {channel: "ChatChannel", room: "1"}.to_json}.to_json,
       ]
       seq = 0
       ws2.on_message do |str|
@@ -49,7 +49,7 @@ describe Cable::Handler do
         seq += 1
         ws2.close if seq >= messages.size
       end
-      ws2.send({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1"}.to_json }.to_json)
+      ws2.send({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
       ws2.run
     end
@@ -63,9 +63,9 @@ describe Cable::Handler do
       ws2 = HTTP::WebSocket.new("ws://#{listen_address}/updates?test_token=1")
 
       messages = [
-        { type: "welcome"}.to_json,
-        { type: "confirm_subscription", identifier: { channel: "ChatChannel", room: "1" }.to_json }.to_json,
-        { identifier: { channel: "ChatChannel", room: "1", }.to_json, message: { message: "test", current_user: "1" }}.to_json
+        {type: "welcome"}.to_json,
+        {type: "confirm_subscription", identifier: {channel: "ChatChannel", room: "1"}.to_json}.to_json,
+        {identifier: {channel: "ChatChannel", room: "1"}.to_json, message: {message: "test", current_user: "1"}}.to_json,
       ]
       seq = 0
       ws2.on_message do |str|
@@ -74,9 +74,9 @@ describe Cable::Handler do
         ws2.close if seq >= messages.size
       end
       # App.cable.subscriptions.create({ channel: "ChatChannel", params: {room: "1"}});
-      ws2.send({"command" => "subscribe", "identifier" => { channel: "ChatChannel", room: "1"}.to_json }.to_json)
+      ws2.send({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
       # App.cable.subscriptions.subscriptions[0].send({message: "test"})
-      ws2.send({"command" => "message", "identifier" => { channel: "ChatChannel", room: "1"}.to_json, "data" => { message: "test"}.to_json }.to_json)
+      ws2.send({"command" => "message", "identifier" => {channel: "ChatChannel", room: "1"}.to_json, "data" => {message: "test"}.to_json}.to_json)
 
       ws2.run
     end
@@ -91,9 +91,9 @@ describe Cable::Handler do
       ws2 = HTTP::WebSocket.new("ws://#{listen_address}/updates?test_token=1")
 
       messages = [
-        { type: "welcome" }.to_json,
-        { type: "confirm_subscription", identifier: { channel: "ChatChannel", room: "1" }.to_json }.to_json,
-        { identifier: { channel: "ChatChannel", room: "1"}.to_json, message: { message: "from Ruby!", current_user: "1" }}.to_json
+        {type: "welcome"}.to_json,
+        {type: "confirm_subscription", identifier: {channel: "ChatChannel", room: "1"}.to_json}.to_json,
+        {identifier: {channel: "ChatChannel", room: "1"}.to_json, message: {message: "from Ruby!", current_user: "1"}}.to_json,
       ]
       seq = 0
       ws2.on_message do |str|
@@ -110,7 +110,7 @@ describe Cable::Handler do
         ws2.close if seq >= messages.size
       end
       # App.cable.subscriptions.create({ channel: "ChatChannel", params: {room: "1"}});
-      ws2.send({command: "subscribe", identifier: { channel: "ChatChannel", room: "1" }.to_json}.to_json)
+      ws2.send({command: "subscribe", identifier: {channel: "ChatChannel", room: "1"}.to_json}.to_json)
       ws2.run
     end
   end
@@ -123,9 +123,9 @@ describe Cable::Handler do
       ws2 = HTTP::WebSocket.new("ws://#{listen_address}/updates?test_token=1")
 
       messages = [
-        { type: "welcome" }.to_json,
-        { type: "confirm_subscription", identifier: { channel: "ChatChannel", room: "1" }.to_json }.to_json,
-        { identifier: { channel: "ChatChannel", room: "1"}.to_json, message: { performed: "invite", params: "3" } }.to_json
+        {type: "welcome"}.to_json,
+        {type: "confirm_subscription", identifier: {channel: "ChatChannel", room: "1"}.to_json}.to_json,
+        {identifier: {channel: "ChatChannel", room: "1"}.to_json, message: {performed: "invite", params: "3"}}.to_json,
       ]
       seq = 0
       ws2.on_message do |str|
@@ -134,9 +134,9 @@ describe Cable::Handler do
         ws2.close if seq >= messages.size
       end
       # App.cable.subscriptions.create({ channel: "ChatChannel", params: {room: "1"}});
-      ws2.send({command: "subscribe", identifier: { channel: "ChatChannel", room: "1" }.to_json }.to_json)
+      ws2.send({command: "subscribe", identifier: {channel: "ChatChannel", room: "1"}.to_json}.to_json)
       # App.cable.subscriptions.subscriptions[0].perform("invite", {invite_id: "3"});
-      ws2.send({command: "message", identifier: { channel: "ChatChannel", room: "1" }.to_json, data: { invite_id: "3", action: "invite" }.to_json }.to_json)
+      ws2.send({command: "message", identifier: {channel: "ChatChannel", room: "1"}.to_json, data: {invite_id: "3", action: "invite"}.to_json}.to_json)
       ws2.run
     end
   end

--- a/spec/cable/payload_spec.cr
+++ b/spec/cable/payload_spec.cr
@@ -13,7 +13,7 @@ describe Cable::Payload do
 
     payload = Cable::Payload.new(payload_json)
     payload.command.should eq("subscribe")
-    payload.identifier.should eq({ channel: "ChatChannel", person: { name: "Foo", age: 32, boom: "boom"}, foo: "bar"}.to_json)
+    payload.identifier.should eq({channel: "ChatChannel", person: {name: "Foo", age: 32, boom: "boom"}, foo: "bar"}.to_json)
     payload.channel.should eq("ChatChannel")
     payload.channel_params.should eq({"person" => {"name" => "Foo", "age" => 32, "boom" => "boom"}, "foo" => "bar"})
   end
@@ -29,7 +29,7 @@ describe Cable::Payload do
 
     payload = Cable::Payload.new(payload_json)
     payload.command.should eq("message")
-    payload.identifier.should eq({ channel: "ChatChannel"}.to_json)
+    payload.identifier.should eq({channel: "ChatChannel"}.to_json)
     payload.channel.should eq("ChatChannel")
     payload.data.should eq({"invite_id" => 3})
     payload.action?.should be_truthy

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -113,7 +113,7 @@ module Cable
       channel.subscribed
 
       return reject(channel) if channel.subscription_rejected?
-        
+
       if stream_identifier = channel.stream_identifier
         Cable.server.subscribe_channel(channel: channel, identifier: stream_identifier)
         Cable::Logger.info "#{channel.class.to_s} is streaming from #{stream_identifier}"

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -62,7 +62,6 @@ module Cable
 
           @channels.delete(identifier)
         end
-
       else
         request = Redis::Request.new
         request << "unsubscribe"

--- a/src/cable/websocket_pinger.cr
+++ b/src/cable/websocket_pinger.cr
@@ -1,7 +1,9 @@
-require "schedule"
+require "tasker"
 
 module Cable
   class WebsocketPinger
+    class PingStoppedException < Exception; end
+
     @@seconds : Int32 | Float64 = 3
 
     def self.run_every(value : Int32 | Float64, &block)
@@ -21,10 +23,9 @@ module Cable
     end
 
     def initialize(@socket : HTTP::WebSocket)
-      runner = Schedule::Runner.new
-      runner.every(Cable::WebsocketPinger.seconds.seconds) do
-        raise Schedule::StopException.new("Stoped") if socket.closed?
-        socket.send({type: "ping", message: Time.utc.to_unix}.to_json)
+      Tasker.every(Cable::WebsocketPinger.seconds.seconds) do
+        raise PingStoppedException.new("Stoped") if @socket.closed?
+        @socket.send({type: "ping", message: Time.utc.to_unix}.to_json)
       end
     end
   end


### PR DESCRIPTION
I ran the specs locally against Crystal 1.0, and they pass:

```
cable on  master [⇡]
❯ ~/Development/crystal/crystal-1.0.0-1/bin/crystal spec
..............................

Finished in 128.44 milliseconds
30 examples, 0 failures, 0 errors, 0 pending
```

I'm not sure how to add multiple crystal versions to Travis CI, but by updating this crystal version restriction, it can be resolved with other shards between 0.35 and 1.0. 