### PR TITLE
Setting names for the spawns.

### DIFF
--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -129,7 +129,7 @@ module Cable
 
     private def process_subscribed_messages
       server = self
-      spawn do
+      spawn(name: "Cable::Server - process_subscribed_messages") do
         while received = fiber_channel.receive
           channel = received[0]
           message = received[1]
@@ -139,7 +139,7 @@ module Cable
     end
 
     private def subscribe
-      spawn do
+      spawn(name: "Cable::Server - subscribe") do
         redis_subscribe.subscribe("_internal") do |on|
           on.message do |channel, message|
             if channel == "_internal" && message == "debug"


### PR DESCRIPTION
Fixes #23

I'm not sure if there's any common naming convention for these or not, but the idea (from what I've heard) is that if one of these spawn dies, then the exception will contain the name allowing us to easier debug where the code failed.