### PR TITLE
Ensure rejected connections are not stored - which causes memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ module ApplicationCable
         self.current_user =  UserQuery.find(user_id)
       end
     end
-
   end
 end
 ```
@@ -117,6 +116,18 @@ class ChatChannel < ApplicationCable::Channel
 
     # You could for example call any method on your user like a .logout one
     # user.logout
+  end
+end
+```
+
+Reject channel subscription if the request is invalid:
+
+```crystal
+class ChatChannel < ApplicationCable::Channel
+  def subscribed
+    reject if user_not_allowed_to_join_chat_room?
+
+    stream_from "chat_#{params["room"]}"
   end
 end
 ```

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -93,6 +93,10 @@ describe Cable::Connection do
       connect do |connection, socket|
         connection.identifier.should eq("98")
       end
+
+      connect(connection_class: ConnectionWithDifferentIndentifierTest) do |connection, socket|
+        connection.identifier.should eq("98")
+      end
     end
   end
 
@@ -374,6 +378,23 @@ private class ConnectionTest < Cable::Connection
   def connect
     if tk = token
       self.identifier = tk
+    end
+    self.current_user = User.new("user98@mail.com")
+    self.organization = Organization.new
+  end
+
+  def broadcast_to(channel, message)
+  end
+end
+
+private class ConnectionWithDifferentIndentifierTest < Cable::Connection
+  identified_by :identifier_test
+  owned_by current_user : User
+  owned_by organization : Organization
+
+  def connect
+    if tk = token
+      self.identifier_test = tk
     end
     self.current_user = User.new("user98@mail.com")
     self.organization = Organization.new

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -308,9 +308,11 @@ describe Cable::Connection do
         sleep 0.1
 
         # Even after broadcasting to Rejection channel, we can check the socket didn't receive it
+        socket.messages.size.should eq(3)
         socket.messages.should contain({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         socket.messages.should contain({"type" => "reject_subscription", "identifier" => {channel: "RejectionChannel"}.to_json}.to_json)
         socket.messages.should contain({"identifier" => {channel: "ChatChannel", room: "1"}.to_json, "message" => {"foo" => "bar"}}.to_json)
+        socket.messages.should_not contain({"identifier" => {channel: "RejectionChannel"}.to_json, "message" => {"foo" => "bar"}}.to_json)
 
         connection.close
         socket.close

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -120,6 +120,8 @@ describe Cable::Connection do
         # we check only the first that is the one we care about, the others make no sense to our test
         Cable::Logger.messages.should contain("An unauthorized connection attempt was rejected")
         socket.closed?.should be_truthy
+
+        Cable.server.connections.should eq({} of String => Cable::Connection)
       end
     end
   end

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -5,7 +5,7 @@ require "./cable/**"
 
 # TODO: Write documentation for `Cable`
 module Cable
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 
   INTERNAL = {
     message_types: {
@@ -30,12 +30,4 @@ module Cable
     setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
   end
   # TODO: Put your code here
-end
-
-# Needs access to connection so we can subscribe to
-# multiple channeels
-class Redis
-  def _connection : Redis::Connection
-    connection
-  end
 end

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -5,7 +5,7 @@ require "./cable/**"
 
 # TODO: Write documentation for `Cable`
 module Cable
-  VERSION = "0.1.1"
+  VERSION = "0.1.0"
 
   INTERNAL = {
     message_types: {

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -12,8 +12,9 @@ module Cable
     getter identifier
     getter connection
     getter stream_identifier : String?
+    getter reject_subscription : Bool = false
 
-    def initialize(@connection : Cable::Connection, @identifier : String, @params : Hash(String, Cable::Payload::RESULT), @reject_subscription : Bool = false)
+    def initialize(@connection : Cable::Connection, @identifier : String, @params : Hash(String, Cable::Payload::RESULT))
     end
 
     def reject
@@ -25,7 +26,6 @@ module Cable
     end
 
     def subscribed
-      # raise Exception.new("Implement the `subscribed` method")
     end
 
     def close

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -1,14 +1,14 @@
 require "uuid"
 
 module Cable
-  class Connection
+  abstract class Connection
     class UnathorizedConnectionException < Exception; end
 
     property internal_identifier : String = "0"
     property connection_identifier : String = ""
 
     getter token : String?
-    getter reject_connection : Bool = false
+    getter? connection_rejected : Bool = false
     getter socket
     getter id : UUID
 
@@ -45,15 +45,10 @@ module Cable
       end
     end
 
-    def connect
-    end
+    abstract def connect
 
     def reject_connection!
-      @reject_connection = true
-    end
-
-    def connection_rejected?
-      reject_connection
+      @connection_rejected = true
     end
 
     def close

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -16,7 +16,7 @@ module Cable
     getter id : String
 
     def identifier
-      ""
+      internal_identifier
     end
 
     macro identified_by(name)

--- a/src/cable/monkeypatch/redis.cr
+++ b/src/cable/monkeypatch/redis.cr
@@ -1,6 +1,6 @@
 # On redis shard it tries to convert the return of command to Nil
 # When returning an array, it raises an exception
-# So we mokeypatch to run the command, ignore it, and retun Nil
+# So we monkey patch to run the command, ignore it, and return Nil
 class Redis
   module CommandExecution
     module ValueOriented
@@ -8,5 +8,11 @@ class Redis
         command(request)
       end
     end
+  end
+
+  # Needs access to connection so we can subscribe to
+  # multiple channels
+  def _connection : Redis::Connection
+    connection
   end
 end


### PR DESCRIPTION
## Background

I found a memory leak in production due to unathorised connections still being stored on the `Cable::Server#connections` hash.

<img width="1207" alt="Screenshot 2021-10-21 at 21 24 23" src="https://user-images.githubusercontent.com/7118473/140604068-e211dda9-6401-47d2-b29c-709e12cb6106.png">

## Implementation

- [x] Add `reject_connection!` helper methods to connection class and use this to ensure rejected connections are never added to the `Cable::Server#connections` hash
- [x] Ensure connection `identified_by(field)` can be used with a different key other than `identifier` while still providing access via `connection.identifier`
- [x] Refactor `connect.reject(channel : Cable::Channel)` to instead support `connection.reject(payload : Cable::Payload)` keeping it consistent with the other methods like `subscribe, unsubscribe and message`
- [x] Refactor some of the macros and unused mock methods from the connection class to make it more readable - Shout out to @jgaskins as this was taken from his fork.
- [x] Update readme to show users how to reject channel subscriptions 