### PR TITLE
Add transmit broadcasting with callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ class ChatChannel < ApplicationCable::Channel
     broadcast_message["message"] = data["message"].to_s
     broadcast_message["current_user_id"] = connection.identifier
     ChatChannel.broadcast_to("chat_#{params["room"]}", broadcast_message)
+    # alternatively you can use the shorthand version
+    broadcast(broadcast_message) # this uses the `stream_from` key already set and broadcasts to everyone
   end
 
   def perform(action, action_params)
@@ -149,18 +151,18 @@ class ChatChannel < ApplicationCable::Channel
   # If you want to ONLY send the current_user a message
   # and none of the other subscribers
   #
-  # use -> connection_transmit(message)
+  # use -> transmit(message)
   def broadcast_welcome_pack_to_single_subscribed_user
-    connection_transmit({ "welcome_pack" => "some cool stuff for this single user" })
+    transmit({ "welcome_pack" => "some cool stuff for this single user" })
   end
 
   # On the other hand,
   # if you want to broadcast a message
   # to all subscribers connected to this channel
   #
-  # use -> transmit(message)
+  # use -> broadcast(message)
   def broadcast_welcome_pack_to_single_subscribed_user
-    transmit("username xyz just joined")
+    broadcast("username xyz just joined")
   end
 
   # you don't need to use transmit functionality

--- a/README.md
+++ b/README.md
@@ -132,6 +132,45 @@ class ChatChannel < ApplicationCable::Channel
 end
 ```
 
+Use callbacks to perform actions or transmit messages once the connection/channel has been subscribed.
+
+```crystal
+class ChatChannel < ApplicationCable::Channel
+  # you can name these callbacks anything you want...
+  # `after_subscribed` can accept 1 or more callbacks to be run in order
+  after_subscribed :broadcast_welcome_pack_to_single_subscribed_user,
+                   :announce_user_joining_to_everyone_else_in_the_channel,
+                   :process_some_stuff
+
+  def subscribed
+    stream_from "chat_#{params["room"]}"
+  end
+
+  # If you want to ONLY send the current_user a message
+  # and none of the other subscribers
+  #
+  # use -> connection_transmit(message)
+  def broadcast_welcome_pack_to_single_subscribed_user
+    connection_transmit({ "welcome_pack" => "some cool stuff for this single user" })
+  end
+
+  # On the other hand,
+  # if you want to broadcast a message
+  # to all subscribers connected to this channel
+  #
+  # use -> transmit(message)
+  def broadcast_welcome_pack_to_single_subscribed_user
+    transmit("username xyz just joined")
+  end
+
+  # you don't need to use transmit functionality
+  def process_some_stuff
+    send_welcome_email_to_user
+    update_their_profile
+  end
+end
+```
+
 Check below on the JavaScript section how to communicate with the Cable backend
 
 ## JavaScript

--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ class ChatChannel < ApplicationCable::Channel
     broadcast_message["message"] = data["message"].to_s
     broadcast_message["current_user_id"] = connection.identifier
     ChatChannel.broadcast_to("chat_#{params["room"]}", broadcast_message)
-    # alternatively you can use the shorthand version
-    broadcast(broadcast_message) # this uses the `stream_from` key already set and broadcasts to everyone
   end
 
   def perform(action, action_params)
@@ -151,7 +149,7 @@ class ChatChannel < ApplicationCable::Channel
   # If you want to ONLY send the current_user a message
   # and none of the other subscribers
   #
-  # use -> transmit(message)
+  # use -> transmit(message), which accepts Hash(String, String) or String
   def broadcast_welcome_pack_to_single_subscribed_user
     transmit({ "welcome_pack" => "some cool stuff for this single user" })
   end
@@ -160,8 +158,8 @@ class ChatChannel < ApplicationCable::Channel
   # if you want to broadcast a message
   # to all subscribers connected to this channel
   #
-  # use -> broadcast(message)
-  def broadcast_welcome_pack_to_single_subscribed_user
+  # use -> broadcast(message), which accepts Hash(String, String) or String
+  def announce_user_joining_to_everyone_else_in_the_channel
     broadcast("username xyz just joined")
   end
 

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -64,17 +64,17 @@ describe Cable::Connection do
       end
     end
 
-    it "accepts without params hash key" do
+    it "blocks the same connection from subscribing to the same channel multiple times" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         sleep 0.1
-        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
         sleep 0.1
-        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         # ensure we only allow subscribing to the same channel once from a connection
         socket.messages.size.should eq(1)
-        socket.messages.should contain({"type" => "confirm_subscription", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+        socket.messages.should contain({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
 
         connection.close
         socket.close

--- a/spec/support/channels/callback_connection_transmit_channel.cr
+++ b/spec/support/channels/callback_connection_transmit_channel.cr
@@ -1,0 +1,15 @@
+class CallbackConnectionTransmitChannel < ApplicationCable::Channel
+  after_subscribed :broadcast_welcome_pack
+
+  def subscribed
+    stream_from "callbacks_02"
+  end
+
+  # testing the type all at once to save time
+  def broadcast_welcome_pack
+    connection_transmit({"welcome" => "hash"})
+    connection_transmit(%({"welcome": "json_string"}))
+    connection_transmit(JSON.parse(%({"welcome": "json"})))
+    connection_transmit("welcome_string")
+  end
+end

--- a/spec/support/channels/callback_connection_transmit_channel.cr
+++ b/spec/support/channels/callback_connection_transmit_channel.cr
@@ -7,9 +7,9 @@ class CallbackConnectionTransmitChannel < ApplicationCable::Channel
 
   # testing the type all at once to save time
   def broadcast_welcome_pack
-    connection_transmit({"welcome" => "hash"})
-    connection_transmit(%({"welcome": "json_string"}))
-    connection_transmit(JSON.parse(%({"welcome": "json"})))
-    connection_transmit("welcome_string")
+    transmit({"welcome" => "hash"})
+    transmit(%({"welcome": "json_string"}))
+    transmit(JSON.parse(%({"welcome": "json"})))
+    transmit("welcome_string")
   end
 end

--- a/spec/support/channels/callback_transmit_channel.cr
+++ b/spec/support/channels/callback_transmit_channel.cr
@@ -1,0 +1,18 @@
+class CallbackTransmitChannel < ApplicationCable::Channel
+  after_subscribed :announce_user_joining_1, :announce_user_joining_2
+
+  def subscribed
+    stream_from "callbacks_01"
+  end
+
+  # testing the type all at once to save time
+  def announce_user_joining_1
+    transmit({"welcome" => "hash"})
+    transmit(%({"welcome": "json_string"}))
+  end
+
+  def announce_user_joining_2
+    transmit(JSON.parse(%({"welcome": "json"})))
+    transmit("welcome_string")
+  end
+end

--- a/spec/support/channels/callback_transmit_channel.cr
+++ b/spec/support/channels/callback_transmit_channel.cr
@@ -7,12 +7,12 @@ class CallbackTransmitChannel < ApplicationCable::Channel
 
   # testing the type all at once to save time
   def announce_user_joining_1
-    transmit({"welcome" => "hash"})
-    transmit(%({"welcome": "json_string"}))
+    broadcast({"welcome" => "hash"})
+    broadcast(%({"welcome": "json_string"}))
   end
 
   def announce_user_joining_2
-    transmit(JSON.parse(%({"welcome": "json"})))
-    transmit("welcome_string")
+    broadcast(JSON.parse(%({"welcome": "json"})))
+    broadcast("welcome_string")
   end
 end

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -78,8 +78,9 @@ module Cable
       Cable.server.publish(channel, message.to_json)
     end
 
-    def transmit(message : String)
+    def broadcast(message : String)
       if stream_identifier.nil?
+        # TODO: change this to .error when supported
         Cable::Logger.info "#{self.class}.transmit(message : String) with #{message} without already using stream_from(stream_identifier)"
       else
         Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
@@ -87,8 +88,9 @@ module Cable
       end
     end
 
-    def transmit(message : JSON::Any)
+    def broadcast(message : JSON::Any)
       if stream_identifier.nil?
+        # TODO: change this to .error when supported
         Cable::Logger.info "#{self.class}.transmit(message : JSON::Any) with #{message} without already using stream_from(stream_identifier)"
       else
         Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
@@ -96,8 +98,9 @@ module Cable
       end
     end
 
-    def transmit(message : Hash(String, String))
+    def broadcast(message : Hash(String, String))
       if stream_identifier.nil?
+        # TODO: change this to .error when supported
         Cable::Logger.info "#{self.class}.transmit(message : Hash(String, String)) with #{message} without already using stream_from(stream_identifier)"
       else
         Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
@@ -106,8 +109,8 @@ module Cable
     end
 
     # broadcast single message to single connection for this channel
-    def connection_transmit(message : String)
-      Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
+    def transmit(message : String)
+      Cable::Logger.info "[ActionCable] transmitting to #{self.class}: #{message}"
       connection.socket.send({
         identifier: identifier,
         message:    Cable.server.safe_decode_message(message),
@@ -115,8 +118,8 @@ module Cable
     end
 
     # broadcast single message to single connection for this channel
-    def connection_transmit(message : JSON::Any)
-      Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
+    def transmit(message : JSON::Any)
+      Cable::Logger.info "[ActionCable] transmitting to #{self.class}: #{message}"
       connection.socket.send({
         identifier: identifier,
         message:    Cable.server.safe_decode_message(message),
@@ -124,8 +127,8 @@ module Cable
     end
 
     # broadcast single message to single connection for this channel
-    def connection_transmit(message : Hash(String, String))
-      Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
+    def transmit(message : Hash(String, String))
+      Cable::Logger.info "[ActionCable] transmitting to #{self.class}: #{message}"
       connection.socket.send({
         identifier: identifier,
         message:    Cable.server.safe_decode_message(message),

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -58,8 +58,6 @@ module Cable
 
     def stream_from(stream_identifier)
       @stream_identifier = stream_identifier
-      Cable.server.subscribe_channel(channel: self, identifier: stream_identifier)
-      Cable::Logger.info "#{self.class} is streaming from #{stream_identifier}"
     end
 
     def self.broadcast_to(channel : String, message : JSON::Any)

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -89,6 +89,11 @@ module Cable
         return
       end
 
+      if stream_identifier = channel.stream_identifier
+        Cable.server.subscribe_channel(channel: channel, identifier: stream_identifier)
+        Cable::Logger.info "#{channel.class.to_s} is streaming from #{stream_identifier}"
+      end
+
       Cable::Logger.info "#{payload.channel} is transmitting the subscription confirmation"
       socket.send({type: "confirm_subscription", identifier: payload.identifier}.to_json)
 

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -91,6 +91,8 @@ module Cable
 
       Cable::Logger.info "#{payload.channel} is transmitting the subscription confirmation"
       socket.send({type: "confirm_subscription", identifier: payload.identifier}.to_json)
+
+      channel.run_after_subscribed_callbacks unless channel.subscription_rejected?
     end
 
     # ensure we only allow subscribing to the same channel once from a connection

--- a/src/cable/websocket_pinger.cr
+++ b/src/cable/websocket_pinger.cr
@@ -24,7 +24,7 @@ module Cable
 
     def initialize(@socket : HTTP::WebSocket)
       Tasker.every(Cable::WebsocketPinger.seconds.seconds) do
-        raise PingStoppedException.new("Stoped") if @socket.closed?
+        raise PingStoppedException.new("Stopped") if @socket.closed?
         @socket.send({type: "ping", message: Time.utc.to_unix}.to_json)
       end
     end


### PR DESCRIPTION
## Purpose

Bring a few features from ActionCable

## Scope

- [x] Add functionality to allow callbacks to be run after a channel has been subscribed to
- [x] Allow many after_subscribed callbacks
- [x] Allow messages to be transmitted only to the current_user for the connection subscribing
- [x] Allow mass broadcast messages to be sent to everyone subscribed to the channel
- [x] Ensure safe parsing/encoding of string messages received from Redis
- [x] Refactor server class to wrap subscribe_channel/unsubscribe_channel calls in mutex and also minor refactoring - taken from @jgaskins forks