### PR TITLE
Allow subscribing to the same channel once from a connection

### DIFF
--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -24,16 +24,13 @@ describe Cable::Connection do
 
     it "accepts without params hash key" do
       connect do |connection, socket|
-        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
         sleep 0.1
 
-        socket.messages.should contain({"type" => "confirm_subscription", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        socket.messages.should contain({"type" => "confirm_subscription", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
 

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -63,6 +63,23 @@ describe Cable::Connection do
         Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\",\"person\":{\"name\":\"Celso\",\"age\":32,\"boom\":\"boom\"}}")
       end
     end
+
+    it "accepts without params hash key" do
+      connect do |connection, socket|
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+        sleep 0.1
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+        sleep 0.1
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+
+        # ensure we only allow subscribing to the same channel once from a connection
+        socket.messages.size.should eq(1)
+        socket.messages.should contain({"type" => "confirm_subscription", "identifier" => {channel: "AppearanceChannel"}.to_json}.to_json)
+
+        connection.close
+        socket.close
+      end
+    end
   end
 
   describe "#unsubscribe" do


### PR DESCRIPTION
## Purpose

To keep close to the ActionCable way of doing things, this change gets us a step closer.

## The problem

Rails doesn't allow the same connection to subscribe to the same channel many times. 
Cable.cr does at the moment, unfortunately.
It actually causes unnecessary memory bloat by allowing the same client connection to get connected many times, receiving many of the same broadcasted messages also

## Solution

Silently do nothing if the client makes this mistake. This is exactly what rails does...
Works perfectly.