### PR TITLE
Offer escape hatch to remove Sec-WebSocket-Protocol response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ And performs an action with:
 App.channels["chat"].perform("status", { status: "My New Status" });
 ```
 
+Vanilla JS Examples
+
+If you want to use this shard with an iOS clients or vanilla JS using react etc. there is an example in the `/examples` folder.
+
+> Note - If your using a vanilla - non action-cable JS client, you may want to disable the action cable response headers as they cause issues on the clients who don't know how to handle them. Set an environment variable like so to disable those headers;
+
+```
+DISABLE_SEC_WEBSOCKET_PROTOCOL_HEADER=true
+```
+
 ## TODO
 
 After reading the docs, I realized I'm using some weird naming for variables / methods, so

--- a/README.md
+++ b/README.md
@@ -125,81 +125,28 @@ Check below on the JavaScript section how to communicate with the Cable backend
 
 ## JavaScript
 
-It works with [ActionCable](https://www.npmjs.com/package/actioncable) JS Client out-of-the-box!! Yeah, that's really cool no? If you need to adapt, make a hack, or something like that?! No, you don't need! Just read the few lines below and start playing with Cable in 5 minutes!
+It works with [ActionCable](https://www.npmjs.com/package/actioncable) JS Client out-of-the-box!! Yeah, that's really cool no? If you need to adapt, make a hack, or something like that?!
 
-If you are using Rails, then you already has a `app/assets/javascripts/cable.js` file that requires `action_cable`, you just need to connect to the right URL (don't forgot the settings you used), to authenticate using JWT use something like:
+No, you don't need! Just read the few lines below and start playing with Cable in 5 minutes!
 
-```js
-(function() {
-  this.App || (this.App = {});
+### ActionCable JS Example
 
-  App.cable = ActionCable.createConsumer(
-    "ws://localhost:5000/cable?token=JWT_TOKEN" // if using the default options
-  );
-}.call(this));
-```
+`/examples/action-cable-js-client.md`
 
-then on your `app/assets/javascripts/channels/chat.js`
-
-```js
-App.channels || (App.channels = {});
-
-App.channels["chat"] = App.cable.subscriptions.create(
-  {
-    channel: "ChatChannel",
-    room: "1"
-  },
-  {
-    connected: function() {
-      return console.log("ChatChannel connected");
-    },
-    disconnected: function() {
-      return console.log("ChatChannel disconnected");
-    },
-    received: function(data) {
-      return console.log("ChatChannel received", data);
-    },
-    rejected: function() {
-      return console.log("ChatChannel rejected");
-    },
-    away: function() {
-      return this.perform("away");
-    },
-    status: function(status) {
-      return this.perform("status", {
-        status: status
-      });
-    }
-  }
-);
-```
-
-Then on your Browser console you can see the message:
-
-> ChatChannel connected
-
-After you load, then you can broadcast messages with:
-
-```js
-App.channels["chat"].send({ message: "Hello World" });
-```
-
-And performs an action with:
-
-```js
-App.channels["chat"].perform("status", { status: "My New Status" });
-```
-
-Vanilla JS Examples
+### Vanilla JS Examples
 
 If you want to use this shard with an iOS clients or vanilla JS using react etc. there is an example in the `/examples` folder.
 
-> Note - If your using a vanilla - non action-cable JS client, you may want to disable the action cable response headers as they cause issues on the clients who don't know how to handle them. Set an environment variable like so to disable those headers;
+> Note - If your using a vanilla - non action-cable JS client, you may want to disable the action cable response headers as they cause issues on the clients who don't know how to handle them. Set an Habitat disable_sec_websocket_protocol_header like so to disable those headers;
 
 ```
-DISABLE_SEC_WEBSOCKET_PROTOCOL_HEADER=true
-```
+# config/cable.cr
 
+Cable.configure do |settings|
+  settings.disable_sec_websocket_protocol_header = true
+end
+```
+4
 ## TODO
 
 After reading the docs, I realized I'm using some weird naming for variables / methods, so

--- a/examples/action-cable-js-client.md
+++ b/examples/action-cable-js-client.md
@@ -1,0 +1,63 @@
+If you are using Rails, then you already has a `app/assets/javascripts/cable.js` file that requires `action_cable`,
+you just need to connect to the right URL (don't forgot the settings you used), to authenticate using JWT use something like:
+
+  ```js
+  (function() {
+    this.App || (this.App = {});
+
+    App.cable = ActionCable.createConsumer(
+    "ws://localhost:5000/cable?token=JWT_TOKEN" // if using the default options
+    );
+  }.call(this));
+  ```
+
+  then on your `app/assets/javascripts/channels/chat.js`
+
+  ```js
+  App.channels || (App.channels = {});
+
+  App.channels["chat"] = App.cable.subscriptions.create(
+  {
+    channel: "ChatChannel",
+    room: "1"
+  },
+  {
+    connected: function() {
+      return console.log("ChatChannel connected");
+    },
+    disconnected: function() {
+      return console.log("ChatChannel disconnected");
+    },
+    received: function(data) {
+      return console.log("ChatChannel received", data);
+    },
+    rejected: function() {
+      return console.log("ChatChannel rejected");
+    },
+    away: function() {
+      return this.perform("away");
+    },
+    status: function(status) {
+      return this.perform("status", {
+        status: status
+      });
+    }
+  }
+  );
+  ```
+
+  Then on your Browser console you can see the message:
+
+  > ChatChannel connected
+
+  After you load, then you can broadcast messages with:
+
+  ```js
+  App.channels["chat"].send({ message: "Hello World" });
+  ```
+
+  And performs an action with:
+
+  ```js
+  App.channels["chat"].perform("status", { status: "My New Status" });
+  ```

--- a/examples/non-action-cable-js-client-with-lucky.html
+++ b/examples/non-action-cable-js-client-with-lucky.html
@@ -1,0 +1,90 @@
+<!-- Open in a web browser with Lucky running -->
+
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Lucky Vanilla JS WebSocket Test</title>
+<script language="javascript" type="text/javascript">
+  var token = 'xyz'
+  var wsUri = `ws://localhost:5000/cable?token=${token}`
+  var output
+
+  function init () {
+    output = document.getElementById('output')
+    testWebSocket()
+  }
+
+  function testWebSocket () {
+    websocket = new WebSocket(wsUri)
+    websocket.onopen = function (evt) {
+      writeToScreen('CONNECTED')
+      subscribe(evt)
+    }
+    websocket.onclose = function (evt) {
+      onClose(evt)
+    }
+    websocket.onmessage = function (evt) {
+      onMessage(evt)
+    }
+    websocket.onerror = function (evt) {
+      onError(evt)
+    }
+  }
+
+  function subscribe (evt) {
+    onSend(
+      JSON.stringify({
+        command: 'subscribe',
+        identifier: JSON.stringify({
+          channel: 'ChatChannel',
+          room: '1'
+        })
+      })
+      )
+  }
+
+  function unsubscribe (evt) {
+    onSend(
+      JSON.stringify({
+        command: 'unsubscribe',
+        identifier: JSON.stringify({
+          channel: 'ChatChannel',
+          room: '1'
+        })
+      })
+      )
+  }
+
+  function onClose (evt) {
+    writeToScreen('DISCONNECTED')
+  }
+
+  function onMessage (evt) {
+    writeToScreen('<b style="color: green;">RESPONSE:</b> <code style="">' + evt.data + '</code>')
+  }
+
+  function onError (evt) {
+    writeToScreen('<span style="color: red;">ERROR:</span> ' + evt.data)
+  }
+
+  function onSend (message) {
+    writeToScreen("<b style='color: blue;'>SENT:</b> " + message)
+    websocket.send(message)
+  }
+
+  function writeToScreen (message) {
+    var pre = document.createElement('p')
+    pre.style.wordWrap = 'break-word'
+    pre.innerHTML = message
+    output.appendChild(pre)
+    window.scrollTo(0, document.body.scrollHeight)
+  }
+
+  window.addEventListener('load', init, false)
+</script>
+
+<h2>WebSocket Test</h2>
+
+<div id="output"></div>
+
+<button onclick="unsubscribe()">Unsubscribe</button>
+<button onclick="subscribe()">Subscribe</button>

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -11,13 +11,13 @@ describe Cable::Handler do
     end
 
     it "allows you to remove undesired actioncable headers" do
-      ENV["DISABLE_SEC_WEBSOCKET_PROTOCOL_HEADER"] = "true"
+      Cable.settings.disable_sec_websocket_protocol_header = true
       handler = Cable::Handler.new(ApplicationCable::Connection)
       request = HTTP::Request.new("GET", "#{Cable.settings.route}?test_token=1", headers_without_sec_websocket_protocol)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
       io_with_context.to_s.should eq("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: 6x90CSU0y750nc+5Do8J0YjG7lM=\r\n\r\n")
-      ENV.delete("DISABLE_SEC_WEBSOCKET_PROTOCOL_HEADER")
+      Cable.settings.disable_sec_websocket_protocol_header = false
     end
 
     it "starts the web pinger" do

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -28,6 +28,7 @@ module Cable
     setting route : String = "/cable", example: "/cable"
     setting token : String = "token", example: "token"
     setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
+    setting disable_sec_websocket_protocol_header : Bool = false
   end
   # TODO: Put your code here
 end

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -14,7 +14,9 @@ module Cable
       path = context.request.path
       Cable::Logger.info "Started GET \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
 
-      context.response.headers["Sec-WebSocket-Protocol"] = "actioncable-v1-json"
+      unless ENV["DISABLE_SEC_WEBSOCKET_PROTOCOL_HEADER"]?
+        context.response.headers["Sec-WebSocket-Protocol"] = "actioncable-v1-json"
+      end
 
       ws = HTTP::WebSocketHandler.new do |socket, context|
         connection = @connection_class.new(context.request, socket)

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -14,7 +14,7 @@ module Cable
       path = context.request.path
       Cable::Logger.info "Started GET \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
 
-      unless ENV["DISABLE_SEC_WEBSOCKET_PROTOCOL_HEADER"]?
+      unless Cable.settings.disable_sec_websocket_protocol_header
         context.response.headers["Sec-WebSocket-Protocol"] = "actioncable-v1-json"
       end
 


### PR DESCRIPTION
## Purpose

If you're using non-action-cable JS clients or iOS etc, the Sec-WebSocket-Protocol headers can cause issues.

## Solution

Add env var escape hatch to remove this header from the response.

## Bonus

Add vanilla JS example also