### PR TITLE
Improve logging and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,32 @@ Cable.configure do |settings|
   settings.disable_sec_websocket_protocol_header = true
 end
 ```
-4
+
+## Debugging
+
+You can create a json endpoint to ping your server and check how things are going.
+
+```crystal
+
+# src/actions/debug/index.cr
+
+class Debug::Index < ApiAction
+  include RequireAuthToken
+
+  get "/debug" do
+    json(Cable.server.debug_json) # Cable.server.debug_json is provided by this shard
+  end
+end
+```
+
+Alternatively, you can ping redis directly using the redis-cli as follows;
+
+```bash
+PUBLISH _internal debug
+```
+
+This will dump a debug status into your logs
+
 ## TODO
 
 After reading the docs, I realized I'm using some weird naming for variables / methods, so

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ On your `src/app_server.cr` add the `Cable::Handler` before `Lucky::RouteHandler
 class AppServer < Lucky::BaseAppServer
   def middleware
     [
-      Cable::Handler.new(ApplicationCable::Connection),
+      Cable::Handler(ApplicationCable::Connection).new, # place before the middleware below
+      Honeybadger::Handler.new,
+      Lucky::ErrorHandler.new(action: Errors::Show),
       Lucky::RouteHandler.new,
     ]
    end
@@ -44,6 +46,21 @@ Cable.configure do |settings|
   settings.route = "/cable"    # the URL your JS Client will connect
   settings.token = "token"     # The query string parameter used to get the token
 end
+```
+
+You may want to tune how to report logging
+
+```crystal
+# config/log.cr
+
+log_levels = {
+  "debug" => Log::Severity::Debug,
+  "info"  => Log::Severity::Info,
+  "error" => Log::Severity::Error,
+}
+
+# use the `CABLE_DEBUG_LEVEL` env var to choose any of the 3 log levels above
+Cable::Logger.level = log_levels[ENV.fetch("CABLE_DEBUG_LEVEL", "info")]
 ```
 
 Then you need to implement a few classes

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -16,9 +16,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
 
@@ -43,9 +40,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\",\"person\":{\"name\":\"Foo\",\"age\":32,\"boom\":\"boom\"}}")
       end
     end
 
@@ -58,9 +52,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\",\"person\":{\"name\":\"Celso\",\"age\":32,\"boom\":\"boom\"}}")
       end
     end
 
@@ -94,10 +85,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the unsubscribe confirmation")
       end
     end
   end
@@ -132,7 +119,6 @@ describe Cable::Connection do
         socket.messages.size.should eq(0)
 
         # we check only the first that is the one we care about, the others make no sense to our test
-        Cable::Logger.messages.should contain("An unauthorized connection attempt was rejected")
         socket.closed?.should be_truthy
 
         Cable.server.connections.should eq({} of String => Cable::Connection)
@@ -151,9 +137,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
 
@@ -169,12 +152,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel#receive({\"message\" => \"Hello\"})")
-        Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: {\"message\" => \"Hello\", \"current_user\" => \"98\"}")
-        Cable::Logger.messages.should contain("ChatChannel transmitting {\"message\" => \"Hello\", \"current_user\" => \"98\"} (via streamed from chat_1)")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
 
@@ -190,12 +167,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel#perform(\"invite\", {\"invite_id\" => \"4\"})")
-        Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: {\"performed\" => \"invite\", \"params\" => \"4\"}")
-        Cable::Logger.messages.should contain("ChatChannel transmitting {\"performed\" => \"invite\", \"params\" => \"4\"} (via streamed from chat_1)")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
   end
@@ -211,9 +182,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
   end
@@ -231,10 +199,6 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("ChatChannel transmitting {\"hello\" => \"Broadcast!\"} (via streamed from chat_1)")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
   end
@@ -253,11 +217,6 @@ describe Cable::Connection do
 
           connection.close
           socket.close
-          Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-          Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-          Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: <turbo-stream></turbo-stream>")
-          Cable::Logger.messages.should contain("ChatChannel transmitting <turbo-stream></turbo-stream> (via streamed from chat_1)")
-          Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
         end
       end
 
@@ -291,11 +250,6 @@ describe Cable::Connection do
 
           connection.close
           socket.close
-          Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-          Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-          Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: {\"foo\" => \"bar\"}")
-          Cable::Logger.messages.should contain("ChatChannel transmitting {\"foo\" => \"bar\"} (via streamed from chat_1)")
-          Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
         end
       end
     end
@@ -314,11 +268,6 @@ describe Cable::Connection do
 
           connection.close
           socket.close
-          Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-          Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-          Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: {\"foo\" => \"bar\"}")
-          Cable::Logger.messages.should contain("ChatChannel transmitting {\"foo\" => \"bar\"} (via streamed from chat_1)")
-          Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
         end
       end
     end
@@ -398,14 +347,7 @@ describe Cable::Connection do
 
         connection.close
         socket.close
-        Cable::Logger.messages.should contain("ChatChannel is streaming from chat_1")
-        Cable::Logger.messages.should contain("ChatChannel is transmitting the subscription confirmation")
-        Cable::Logger.messages.should contain("RejectionChannel is transmitting the subscription rejection")
-        Cable::Logger.messages.should contain("[ActionCable] Broadcasting to chat_1: {\"foo\" => \"bar\"}")
         # and here we can confirm the message was broadcasted
-        Cable::Logger.messages.should contain("ChatChannel transmitting {\"foo\" => \"bar\"} (via streamed from chat_1)")
-        Cable::Logger.messages.should contain("[ActionCable] Broadcasting to rejection: {\"foo\" => \"bar\"}")
-        Cable::Logger.messages.should contain("ChatChannel stopped streaming from {\"channel\":\"ChatChannel\",\"room\":\"1\"}")
       end
     end
   end

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Cable::Handler do
   describe "basic handling" do
     it "matches the right route" do
-      handler = Cable::Handler.new(ApplicationCable::Connection)
+      handler = Cable::Handler(ApplicationCable::Connection).new
       request = HTTP::Request.new("GET", "#{Cable.settings.route}?test_token=1", headers)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
@@ -168,7 +168,7 @@ describe Cable::Handler do
 
   describe "the error handling" do
     it "doesn't match the wrong route" do
-      handler = Cable::Handler.new(ApplicationCable::Connection)
+      handler = Cable::Handler(ApplicationCable::Connection).new
       request = HTTP::Request.new("GET", "/unknown_route?test_token=1", headers)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
@@ -176,7 +176,7 @@ describe Cable::Handler do
     end
 
     it "doesn't upgrade with wrong headers (without Upgrade header)" do
-      handler = Cable::Handler.new(ApplicationCable::Connection)
+      handler = Cable::Handler(ApplicationCable::Connection).new
       headers_without_upgrade = headers
       headers_without_upgrade.delete("Upgrade")
       request = HTTP::Request.new("GET", "/unknown_route?test_token=1", headers_without_upgrade)
@@ -186,7 +186,7 @@ describe Cable::Handler do
     end
 
     it "doesn't upgrade with wrong headers (without Connection header)" do
-      handler = Cable::Handler.new(ApplicationCable::Connection)
+      handler = Cable::Handler(ApplicationCable::Connection).new
       headers_without_connection = headers
       headers_without_connection.delete("Connection")
       request = HTTP::Request.new("GET", "/unknown_route?test_token=1", headers_without_connection)
@@ -217,7 +217,7 @@ private def start_server
   spawn do
     # Make pinger real fast so we don't need to wait
     http_ref = nil
-    http_server = http_ref = HTTP::Server.new([Cable::Handler.new(ApplicationCable::Connection)])
+    http_server = http_ref = HTTP::Server.new([Cable::Handler(ApplicationCable::Connection).new])
     address = http_server.bind_unused_port
     address_chan.send(address)
     http_server.listen

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -12,7 +12,7 @@ describe Cable::Handler do
 
     it "allows you to remove undesired actioncable headers" do
       Cable.settings.disable_sec_websocket_protocol_header = true
-      handler = Cable::Handler.new(ApplicationCable::Connection)
+      handler = Cable::Handler(ApplicationCable::Connection).new
       request = HTTP::Request.new("GET", "#{Cable.settings.route}?test_token=1", headers_without_sec_websocket_protocol)
 
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,8 +4,6 @@ require "./support/application_cable/connection"
 require "./support/application_cable/channel"
 require "./support/channels/*"
 
-Cable::Logger.suppress_output
-
 Cable.configure do |settings|
   settings.route = "/updates"
   settings.token = "test_token"
@@ -13,5 +11,4 @@ end
 
 Spec.before_each do
   Cable.restart
-  Cable::Logger.reset_messages
 end

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -5,7 +5,7 @@ require "./cable/**"
 
 # TODO: Write documentation for `Cable`
 module Cable
-  VERSION = "0.2.0"
+  VERSION = "0.1.0"
 
   INTERNAL = {
     message_types: {

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -5,7 +5,7 @@ require "./cable/**"
 
 # TODO: Write documentation for `Cable`
 module Cable
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 
   INTERNAL = {
     message_types: {

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -14,6 +14,7 @@ module Cable
       ping:         "ping",
       confirmation: "confirm_subscription",
       rejection:    "reject_subscription",
+      unsubscribe:  "confirm_unsubscription",
     },
     disconnect_reasons: {
       unauthorized:    "unauthorized",
@@ -21,14 +22,19 @@ module Cable
       server_restart:  "server_restart",
     },
     default_mount_path: "/cable",
-    protocols:          ["actioncable-v1-json", "actioncable-unsupported"].freeze,
+    protocols:          ["actioncable-v1-json", "actioncable-unsupported"],
   }
 
   Habitat.create do
-    setting route : String = "/cable", example: "/cable"
+    setting route : String = Cable.message(:default_mount_path), example: "/cable"
     setting token : String = "token", example: "token"
     setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
     setting disable_sec_websocket_protocol_header : Bool = false
   end
+
+  def self.message(event : Symbol)
+    INTERNAL[:message_types][event]
+  end
+
   # TODO: Put your code here
 end

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -25,17 +25,13 @@ module Cable
     getter identifier
     getter connection
     getter stream_identifier : String?
-    getter reject_subscription : Bool = false
+    getter? subscription_rejected : Bool = false
 
     def initialize(@connection : Cable::Connection, @identifier : String, @params : Hash(String, Cable::Payload::RESULT))
     end
 
     def reject
-      @reject_subscription = true
-    end
-
-    def subscription_rejected?
-      @reject_subscription
+      @subscription_rejected = true
     end
 
     def subscribed
@@ -67,48 +63,45 @@ module Cable
 
     # It's important that we don't call message.to_json
     def self.broadcast_to(channel : String, message : String)
-      Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
+      Cable::Logger.info { "[ActionCable] Broadcasting to #{channel}: #{message}" }
       Cable.server.publish(channel, message)
     end
 
     def self.broadcast_to(channel : String, message : Hash(String, String))
-      Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
+      Cable::Logger.info { "[ActionCable] Broadcasting to #{channel}: #{message}" }
       Cable.server.publish(channel, message.to_json)
     end
 
     def broadcast(message : String)
       if stream_identifier.nil?
-        # TODO: change this to .error when supported
-        Cable::Logger.info "#{self.class}.transmit(message : String) with #{message} without already using stream_from(stream_identifier)"
+        Cable::Logger.error { "#{self.class}.transmit(message : String) with #{message} without already using stream_from(stream_identifier)" }
       else
-        Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
+        Cable::Logger.info { "[ActionCable] Broadcasting to #{self.class}: #{message}" }
         Cable.server.send_to_channels(stream_identifier.not_nil!, message)
       end
     end
 
     def broadcast(message : JSON::Any)
       if stream_identifier.nil?
-        # TODO: change this to .error when supported
-        Cable::Logger.info "#{self.class}.transmit(message : JSON::Any) with #{message} without already using stream_from(stream_identifier)"
+        Cable::Logger.error { "#{self.class}.transmit(message : JSON::Any) with #{message} without already using stream_from(stream_identifier)" }
       else
-        Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
+        Cable::Logger.info { "[ActionCable] Broadcasting to #{self.class}: #{message}" }
         Cable.server.send_to_channels(stream_identifier.not_nil!, message)
       end
     end
 
     def broadcast(message : Hash(String, String))
       if stream_identifier.nil?
-        # TODO: change this to .error when supported
-        Cable::Logger.info "#{self.class}.transmit(message : Hash(String, String)) with #{message} without already using stream_from(stream_identifier)"
+        Cable::Logger.error { "#{self.class}.transmit(message : Hash(String, String)) with #{message} without already using stream_from(stream_identifier)" }
       else
-        Cable::Logger.info "[ActionCable] Broadcasting to #{self.class}: #{message}"
+        Cable::Logger.info { "[ActionCable] Broadcasting to #{self.class}: #{message}" }
         Cable.server.send_to_channels(stream_identifier.not_nil!, message.to_json)
       end
     end
 
     # broadcast single message to single connection for this channel
     def transmit(message : String)
-      Cable::Logger.info "[ActionCable] transmitting to #{self.class}: #{message}"
+      Cable::Logger.info { "[ActionCable] transmitting to #{self.class}: #{message}" }
       connection.socket.send({
         identifier: identifier,
         message:    Cable.server.safe_decode_message(message),
@@ -117,7 +110,7 @@ module Cable
 
     # broadcast single message to single connection for this channel
     def transmit(message : JSON::Any)
-      Cable::Logger.info "[ActionCable] transmitting to #{self.class}: #{message}"
+      Cable::Logger.info { "[ActionCable] transmitting to #{self.class}: #{message}" }
       connection.socket.send({
         identifier: identifier,
         message:    Cable.server.safe_decode_message(message),
@@ -126,7 +119,7 @@ module Cable
 
     # broadcast single message to single connection for this channel
     def transmit(message : Hash(String, String))
-      Cable::Logger.info "[ActionCable] transmitting to #{self.class}: #{message}"
+      Cable::Logger.info { "[ActionCable] transmitting to #{self.class}: #{message}" }
       connection.socket.send({
         identifier: identifier,
         message:    Cable.server.safe_decode_message(message),

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -43,7 +43,7 @@ module Cable
 
     def close
       Cable.server.unsubscribe_channel(channel: self, identifier: @stream_identifier.not_nil!) unless @stream_identifier.nil?
-      Cable::Logger.info "#{self.class.name} stopped streaming from #{identifier}"
+      Cable::Logger.info { "#{self.class.name} stopped streaming from #{identifier}" }
       unsubscribed
     end
 
@@ -61,7 +61,7 @@ module Cable
     end
 
     def self.broadcast_to(channel : String, message : JSON::Any)
-      Cable::Logger.info "[ActionCable] Broadcasting to #{channel}: #{message}"
+      Cable::Logger.info { "[ActionCable] Broadcasting to #{channel}: #{message}" }
       Cable.server.publish(channel, message.to_json)
     end
 

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -102,7 +102,7 @@ module Cable
       end
 
       Cable::Logger.info { "#{payload.channel} is transmitting the subscription confirmation" }
-      socket.send({type: "confirm_subscription", identifier: payload.identifier}.to_json)
+      socket.send({type: Cable.message(:confirmation), identifier: payload.identifier}.to_json)
 
       channel.run_after_subscribed_callbacks unless channel.subscription_rejected?
     end
@@ -118,7 +118,7 @@ module Cable
       if channel = Connection::CHANNELS[connection_identifier].delete(payload.identifier)
         channel.close
         Cable::Logger.info { "#{payload.channel} is transmitting the unsubscribe confirmation" }
-        socket.send({type: "confirm_unsubscription", identifier: payload.identifier}.to_json)
+        socket.send({type: Cable.message(:unsubscribe), identifier: payload.identifier}.to_json)
       end
     end
 
@@ -126,7 +126,7 @@ module Cable
       if channel = Connection::CHANNELS[connection_identifier].delete(payload.identifier)
         channel.unsubscribed
         Cable::Logger.info { "#{channel.class.to_s} is transmitting the subscription rejection" }
-        socket.send({type: "reject_subscription", identifier: payload.identifier}.to_json)
+        socket.send({type: Cable.message(:rejection), identifier: payload.identifier}.to_json)
       end
     end
 

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -11,14 +11,13 @@ module Cable
     getter? connection_rejected : Bool = false
     getter socket
     getter id : UUID
+    getter started_at : Time = Time.utc
 
     CHANNELS = {} of String => Hash(String, Cable::Channel)
 
     def identifier
       internal_identifier
     end
-
-    getter started_at : Time = Time.utc
 
     macro identified_by(name)
       property {{name.id}} = ""
@@ -55,6 +54,7 @@ module Cable
 
     def close
       return true unless Connection::CHANNELS.has_key?(connection_identifier)
+
       Connection::CHANNELS[connection_identifier].each do |identifier, channel|
         channel.close
         Connection::CHANNELS[connection_identifier].delete(identifier)

--- a/src/cable/debug.cr
+++ b/src/cable/debug.cr
@@ -1,0 +1,60 @@
+# messy debug methods out of the way from the main functional logic
+
+module Cable
+  module Debug
+    def debug_json
+      _channels = {} of String => Set(String)
+
+      @channels.each do |k, v|
+        _channels[v.first.class.to_s] ||= Set{k}
+        _channels[v.first.class.to_s] << k
+      end
+
+      {
+        "connections"         => @connections.size,
+        "channels"            => @channels.size,
+        "channels_mounted"    => _channels,
+        "connections_mounted" => @connections.map do |key, connection|
+          connections_mounted_channels = [] of Hash(String, String | Nil)
+          @channels.each do |_, v|
+            v.each do |channel|
+              next unless channel.connection.connection_identifier == key
+              connections_mounted_channels << {
+                "channel" => channel.class.to_s,
+                "key"     => channel.stream_identifier,
+              }
+            end
+          end
+
+          {
+            "key"        => key,
+            "identifier" => connection.identifier,
+            "started_at" => connection.started_at.to_s("%Y-%m-%dT%H:%M:%S.%6N"),
+            "channels"   => connections_mounted_channels,
+          }
+        end,
+      }
+    end
+
+    def debug
+      Cable::Logger.debug { "-" * 80 }
+      Cable::Logger.debug { "Some Good Information" }
+      Cable::Logger.debug { "Connections" }
+      @connections.each do |k, v|
+        Cable::Logger.debug { "Connection Key: #{k}" }
+      end
+      Cable::Logger.debug { "Channels" }
+      @channels.each do |k, v|
+        Cable::Logger.debug { "Channel Key: #{k}" }
+        Cable::Logger.debug { "Channels" }
+        v.each do |channel|
+          Cable::Logger.debug { "From Channel: #{channel.connection.connection_identifier}" }
+          Cable::Logger.debug { "Params: #{channel.params}" }
+          Cable::Logger.debug { "ID: #{channel.identifier}" }
+          Cable::Logger.debug { "Stream ID:: #{channel.stream_identifier}" }
+        end
+      end
+      Cable::Logger.debug { "-" * 80 }
+    end
+  end
+end

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -12,7 +12,7 @@ module Cable
 
       remote_address = context.request.remote_address
       path = context.request.path
-      Cable::Logger.info "Started GET \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
+      Cable::Logger.info { "Started GET \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}" }
 
       unless Cable.settings.disable_sec_websocket_protocol_header
         context.response.headers["Sec-WebSocket-Protocol"] = "actioncable-v1-json"
@@ -32,6 +32,7 @@ module Cable
 
         socket.on_ping do
           socket.pong context.request.path
+          Cable::Logger.debug { "Ping received" }
         end
 
         # Handle incoming message and echo back to the client
@@ -41,17 +42,17 @@ module Cable
           rescue e : Cable::Connection::UnathorizedConnectionException
             # do nothing, this is planned
           rescue e : Exception
-            Cable::Logger.info "Exception: #{e.message}"
+            Cable::Logger.error { "Exception: #{e.message}" }
           end
         end
 
         socket.on_close do
           Cable.server.remove_connection(connection_id)
-          Cable::Logger.info "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}"
+          Cable::Logger.info { "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}" }
         end
       end
 
-      Cable::Logger.info "Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)"
+      Cable::Logger.info { "Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)" }
       ws.call(context)
     end
 

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -23,7 +23,7 @@ module Cable
         Cable.server.add_connection(connection) unless connection.connection_rejected?
 
         # Send welcome message to the client
-        socket.send({type: "welcome"}.to_json)
+        socket.send({type: Cable.message(:welcome)}.to_json)
 
         Cable::WebsocketPinger.build(socket)
 

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -1,11 +1,8 @@
 require "http/server"
 
 module Cable
-  class Handler
+  class Handler(T)
     include HTTP::Handler
-
-    def initialize(@connection_class : Cable::Connection.class)
-    end
 
     def call(context)
       return call_next(context) unless ws_route_found?(context) && websocket_upgrade_request?(context)
@@ -19,7 +16,7 @@ module Cable
       end
 
       ws = HTTP::WebSocketHandler.new do |socket, context|
-        connection = @connection_class.new(context.request, socket)
+        connection = T.new(context.request, socket)
         connection_id = connection.connection_identifier
 
         # we should not add any connections which have been rejected

--- a/src/cable/logger.cr
+++ b/src/cable/logger.cr
@@ -1,34 +1,5 @@
 require "log"
 
 module Cable
-  class Logger
-    @@show : Bool = true
-    @@messages = [] of String
-    LOG = ::Log.for("cable")
-
-    def self.suppress_output
-      @@show = false
-    end
-
-    def self.show_output
-      @@show = true
-    end
-
-    def self.info(message)
-      return Cable::Logger::LOG.info { message } if @@show
-      @@messages << message
-    end
-
-    def self.debug(message)
-      return Cable::Logger::LOG.debug { message } if @@show
-    end
-
-    def self.reset_messages
-      @@messages = [] of String
-    end
-
-    def self.messages
-      @@messages
-    end
-  end
+  Logger = Log.for(self)
 end

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -23,9 +23,10 @@ module Cable
     getter redis_publish = Redis.new(url: Cable.settings.url)
     getter fiber_channel = ::Channel({String, String}).new
 
+    @channels = {} of String => Channels
+    @channel_mutex = Mutex.new
+
     def initialize
-      @channels = {} of String => Channels
-      @channel_mutex = Mutex.new
       subscribe
       process_subscribed_messages
     end
@@ -140,7 +141,7 @@ module Cable
         redis_subscribe.subscribe("_internal") do |on|
           on.message do |channel, message|
             if channel == "_internal" && message == "debug"
-              puts self.debug
+              debug
             else
               fiber_channel.send({channel, message})
               Cable::Logger.debug { "Cable::Server#subscribe channel:#{channel} message:#{message}" }

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -16,6 +16,8 @@ module Cable
   end
 
   class Server
+    include Debug
+
     getter connections = {} of String => Connection
     getter redis_subscribe = Redis.new(url: Cable.settings.url)
     getter redis_publish = Redis.new(url: Cable.settings.url)
@@ -100,40 +102,6 @@ module Cable
       Cable::Logger.error { "IO::Error Exception: #{e.message} -> #{self.class.name}#send_to_channels(channel, message)" }
     end
 
-    def debug_json
-      _channels = {} of String => Set(String)
-
-      @channels.each do |k, v|
-        channels[v.first.class.to_s] ||= Set{k}
-        channels[v.first.class.to_s] << k
-      end
-
-      {
-        "connections"         => @connections.size,
-        "channels"            => @channels.size,
-        "channels_mounted"    => _channels,
-        "connections_mounted" => @connections.map do |key, connection|
-          connections_mounted_channels = [] of Hash(String, String | Nil)
-          @channels.each do |_, v|
-            v.each do |channel|
-              next unless channel.connection.connection_identifier == key
-              connections_mounted_channels << {
-                "channel" => channel.class.to_s,
-                "key"     => channel.stream_identifier,
-              }
-            end
-          end
-
-          {
-            "key"        => key,
-            "identifier" => connection.identifier,
-            "started_at" => connection.started_at.to_s("%Y-%m-%dT%H:%M:%S.%6N"),
-            "channels"   => connections_mounted_channels,
-          }
-        end,
-      }
-    end
-
     def safe_decode_message(message)
       case message
       when String
@@ -143,27 +111,6 @@ module Cable
       end
     rescue JSON::ParseException
       message
-    end
-
-    def debug
-      Cable::Logger.debug { "-" * 80 }
-      Cable::Logger.debug { "Some Good Information" }
-      Cable::Logger.debug { "Connections" }
-      @connections.each do |k, v|
-        Cable::Logger.debug { "Connection Key: #{k}" }
-      end
-      Cable::Logger.debug { "Channels" }
-      @channels.each do |k, v|
-        Cable::Logger.debug { "Channel Key: #{k}" }
-        Cable::Logger.debug { "Channels" }
-        v.each do |channel|
-          Cable::Logger.debug { "From Channel: #{channel.connection.connection_identifier}" }
-          Cable::Logger.debug { "Params: #{channel.params}" }
-          Cable::Logger.debug { "ID: #{channel.identifier}" }
-          Cable::Logger.debug { "Stream ID:: #{channel.stream_identifier}" }
-        end
-      end
-      Cable::Logger.debug { "-" * 80 }
     end
 
     def shutdown

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -89,14 +89,49 @@ module Cable
         if channel.connection.socket.closed?
           channel.close
         else
-          Cable::Logger.info "#{channel.class} transmitting #{parsed_message} (via streamed from #{channel.stream_identifier})"
+          Cable::Logger.info { "#{channel.class} transmitting #{parsed_message} (via streamed from #{channel.stream_identifier})" }
           channel.connection.socket.send({
             identifier: channel.identifier,
             message:    parsed_message,
           }.to_json)
         end
       end
-    rescue IO::Error
+    rescue e : IO::Error
+      Cable::Logger.error { "IO::Error Exception: #{e.message} -> #{self.class.name}#send_to_channels(channel, message)" }
+    end
+
+    def debug_json
+      _channels = {} of String => Set(String)
+
+      @channels.each do |k, v|
+        channels[v.first.class.to_s] ||= Set{k}
+        channels[v.first.class.to_s] << k
+      end
+
+      {
+        "connections"         => @connections.size,
+        "channels"            => @channels.size,
+        "channels_mounted"    => _channels,
+        "connections_mounted" => @connections.map do |key, connection|
+          connections_mounted_channels = [] of Hash(String, String | Nil)
+          @channels.each do |_, v|
+            v.each do |channel|
+              next unless channel.connection.connection_identifier == key
+              connections_mounted_channels << {
+                "channel" => channel.class.to_s,
+                "key"     => channel.stream_identifier,
+              }
+            end
+          end
+
+          {
+            "key"        => key,
+            "identifier" => connection.identifier,
+            "started_at" => connection.started_at.to_s("%Y-%m-%dT%H:%M:%S.%6N"),
+            "channels"   => connections_mounted_channels,
+          }
+        end,
+      }
     end
 
     def safe_decode_message(message)
@@ -111,24 +146,24 @@ module Cable
     end
 
     def debug
-      Cable::Logger.debug "-" * 80
-      Cable::Logger.debug "Some Good Information"
-      Cable::Logger.debug "Connections"
+      Cable::Logger.debug { "-" * 80 }
+      Cable::Logger.debug { "Some Good Information" }
+      Cable::Logger.debug { "Connections" }
       @connections.each do |k, v|
-        Cable::Logger.debug "Connection Key: #{k}"
+        Cable::Logger.debug { "Connection Key: #{k}" }
       end
-      Cable::Logger.debug "Channels"
+      Cable::Logger.debug { "Channels" }
       @channels.each do |k, v|
-        Cable::Logger.debug "Channel Key: #{k}"
-        Cable::Logger.debug "Channels"
+        Cable::Logger.debug { "Channel Key: #{k}" }
+        Cable::Logger.debug { "Channels" }
         v.each do |channel|
-          Cable::Logger.debug "From Channel: #{channel.connection.connection_identifier}"
-          Cable::Logger.debug "Params: #{channel.params}"
-          Cable::Logger.debug "ID: #{channel.identifier}"
-          Cable::Logger.debug "Stream ID:: #{channel.stream_identifier}"
+          Cable::Logger.debug { "From Channel: #{channel.connection.connection_identifier}" }
+          Cable::Logger.debug { "Params: #{channel.params}" }
+          Cable::Logger.debug { "ID: #{channel.identifier}" }
+          Cable::Logger.debug { "Stream ID:: #{channel.stream_identifier}" }
         end
       end
-      Cable::Logger.debug "-" * 80
+      Cable::Logger.debug { "-" * 80 }
     end
 
     def shutdown
@@ -148,6 +183,7 @@ module Cable
         while received = fiber_channel.receive
           channel, message = received
           server.send_to_channels(channel, message)
+          Cable::Logger.debug { "Cable::Server#process_subscribed_messages channel:#{channel} message:#{message}" }
         end
       end
     end
@@ -160,6 +196,7 @@ module Cable
               puts self.debug
             else
               fiber_channel.send({channel, message})
+              Cable::Logger.debug { "Cable::Server#subscribe channel:#{channel} message:#{message}" }
             end
           end
         end

--- a/src/cable/websocket_pinger.cr
+++ b/src/cable/websocket_pinger.cr
@@ -25,7 +25,7 @@ module Cable
     def initialize(@socket : HTTP::WebSocket)
       Tasker.every(Cable::WebsocketPinger.seconds.seconds) do
         raise PingStoppedException.new("Stopped") if @socket.closed?
-        @socket.send({type: "ping", message: Time.utc.to_unix}.to_json)
+        @socket.send({type: Cable.message(:ping), message: Time.utc.to_unix}.to_json)
       end
     end
   end


### PR DESCRIPTION
Fixes: #19 

- [x] There was a lot of spec logic around logging, I guess it seemed like it made sense to remove that?
- [x] Provided developers was an example of how they can change the logging level.
- [x] Refactored a bunch of rescue statements around the code to log the rescued errors.
- [x] Refactored the base connection class type mounting method.
- [x] Added a debug_json method which can be exposed on any rest endpoint to ping and get stats on the current state of the server

Let me know what you guys think?