### PR TITLE
Adding an option for a pooled redis publish client.

### DIFF
--- a/src/cable.cr
+++ b/src/cable.cr
@@ -30,6 +30,9 @@ module Cable
     setting token : String = "token", example: "token"
     setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
     setting disable_sec_websocket_protocol_header : Bool = false
+    setting pool_redis_publish : Bool = false
+    setting redis_pool_size : Int32 = 5
+    setting redis_pool_timeout : Float64 = 5.0
   end
 
   def self.message(event : Symbol)

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -19,8 +19,20 @@ module Cable
     include Debug
 
     getter connections = {} of String => Connection
+
+    getter redis_publish do
+      if Cable.settings.pool_redis_publish
+        Redis::PooledClient.new(
+          url: Cable.settings.url,
+          pool_size: Cable.settings.redis_pool_size,
+          pool_timeout: Cable.settings.redis_pool_timeout
+        )
+      else
+        Redis.new(url: Cable.settings.url)
+      end
+    end
+
     getter redis_subscribe = Redis.new(url: Cable.settings.url)
-    getter redis_publish = Redis.new(url: Cable.settings.url)
     getter fiber_channel = ::Channel({String, String}).new
 
     @channels = {} of String => Channels


### PR DESCRIPTION
This adds a configuration option to use a pooled redis connection. This is the recommended way to use it in a web context.

https://github.com/stefanwille/crystal-redis/issues/76
https://github.com/stefanwille/crystal-redis/issues/97