### PR TITLE
Fix memory leak

### DIFF
--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -25,7 +25,7 @@ module Cable
         # Send welcome message to the client
         socket.send({type: Cable.message(:welcome)}.to_json)
 
-        Cable::WebsocketPinger.build(socket)
+        ws_pinger = Cable::WebsocketPinger.build(socket)
 
         socket.on_ping do
           socket.pong context.request.path
@@ -44,6 +44,7 @@ module Cable
         end
 
         socket.on_close do
+          ws_pinger.stop
           Cable.server.remove_connection(connection_id)
           Cable::Logger.info { "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc.to_s}" }
         end


### PR DESCRIPTION
The `Tasker::Task` that pings each websocket was not being cleaned up and garbage-collected, which meant that the WebSocket itself was also not being GCed since it (and the WebSocketPinger itself) was referenced inside the task block, leading to a leak for every single WebSocket.

I had a feeling this was the case because CPU and RAM consumption were not static after a lot of WebSockets had been connected, even if they were *no longer* connected. Turns out every single WebSocket was still being pinged or raising an exception if it were closed. That exception was not causing the `Tasker::Task` to stop.

I discovered this by putting some debug logging inside the task block (which I forgot to remove … oops) and performed the very definitely scientific test I outlined in #50 — mashing refresh a bunch of times. With only one WebSocket open to the server (the rest had been closed), I should have seen a log message once every 3 seconds, I was seeing hundreds of them per second. With this patch, I saw them at the expected cadence.

Fixes #50 