### PR TITLE
Add logic to ensure rejected connections are properly handled

### DIFF
--- a/spec/support/application_cable/connection.cr
+++ b/spec/support/application_cable/connection.cr
@@ -6,6 +6,8 @@ module ApplicationCable
       if tk = token
         self.identifier = tk
       end
+
+      reject_unauthorized_connection if token == "reject"
     end
   end
 end


### PR DESCRIPTION
We added some logic a while back to ensure the connection are never actually added - https://github.com/cable-cr/cable/pull/34
But In production, I found more edge cases where connections didn't get closed correctly in a meaningful way to the client. The way we handle specific errors causes unknown client states. 
Forcing the socket to be closed so the client can try again seems to do the job.
I also kept seeing an `Unhandled exception in spawn: Missing hash key` error. There is a fix for that.