### PR TITLE
Add Redis connection health checks and restarts

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,6 +7,8 @@ require "./support/channels/*"
 Cable.configure do |settings|
   settings.route = "/updates"
   settings.token = "test_token"
+  settings.redis_ping_interval = 2.seconds
+  settings.restart_error_allowance = 2
 end
 
 Spec.before_each do

--- a/spec/support/channels/chat_channel.cr
+++ b/spec/support/channels/chat_channel.cr
@@ -12,6 +12,7 @@ class ChatChannel < ApplicationCable::Channel
       broadcast_message["message"] = message["message"].to_s
     end
     broadcast_message["current_user"] = connection.identifier
+    raise IO::Error.new("Invalid message") if broadcast_message["message"] == "raise"
     ChatChannel.broadcast_to("chat_#{params["room"]}", broadcast_message)
   end
 

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -33,6 +33,8 @@ module Cable
     setting pool_redis_publish : Bool = false
     setting redis_pool_size : Int32 = 5
     setting redis_pool_timeout : Float64 = 5.0
+    setting redis_ping_interval : Time::Span = 15.seconds
+    setting restart_error_allowance : Int32 = 20
   end
 
   def self.message(event : Symbol)

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -58,6 +58,9 @@ module Cable
             # handle all other exceptions
             socket.close(HTTP::WebSocket::CloseCode::InternalServerError, "Internal Server Error")
             Cable.server.remove_connection(connection_id)
+            # handle restart
+            Cable.server.count_error!
+            Cable.restart if Cable.server.restart?
             Cable::Logger.error { "Exception: #{e.message}" }
           end
         end

--- a/src/cable/redis_pinger.cr
+++ b/src/cable/redis_pinger.cr
@@ -1,0 +1,34 @@
+require "tasker"
+
+module Cable
+  class RedisPinger
+    private getter task : Tasker::Task
+
+    def initialize(@server : Cable::Server)
+      @task = Tasker.every(Cable.settings.redis_ping_interval) do
+        check_redis_subscribe
+        check_redis_publish
+      rescue e
+        Cable::Logger.error { "Cable::RedisPinger Exception: #{e.class.name} -> #{e.message}" }
+        # Restart cable if something happened
+        Cable.server.count_error!
+        Cable.restart if Cable.server.restart?
+      end
+    end
+
+    def stop
+      @task.cancel
+    end
+
+    def check_redis_subscribe
+      Cable.server.publish("_internal", "ping")
+    end
+
+    def check_redis_publish
+      request = Redis::Request.new
+      request << "ping"
+      result = @server.redis_subscribe._connection.send(request)
+      Cable::Logger.debug { "Cable::RedisPinger.check_redis_publish -> #{result}" }
+    end
+  end
+end


### PR DESCRIPTION
Redis has complexities that need to be considered;

1. Redis Pub/Sub works well until you lose the connection...
2. Redis connections can go stale without activity.
3. Redis DB's have a buffer related to the message sizes called [Output Buffer Limits](https://redis.io/docs/reference/clients/#output-buffer-limits). Exceeding this buffer will not disconnect the connection. It just yields it dead. You cannot know about this except by monitoring logs/metrics.

This PR helps to mitigate issues 1 and 2

We've been running these changes in production (with these changes https://github.com/cable-cr/cable/pull/54 and a different [Redis shard](https://github.com/jgaskins/redis)) with excellent results;

### 1 month of APM metrics

<img width="1487" alt="Screenshot 2022-10-08 at 18 50 23" src="https://user-images.githubusercontent.com/7118473/194717149-a34adb80-59f3-48ff-9602-cecc7e9055ae.png">

> NOTE: No automated restarts at all in the last month

Workloads
<img width="1481" alt="Screenshot 2022-10-08 at 18 50 47" src="https://user-images.githubusercontent.com/7118473/194717190-f5e782fb-311b-4a0b-901a-010562067956.png">
<img width="1602" alt="Screenshot 2022-10-08 at 18 30 45" src="https://user-images.githubusercontent.com/7118473/194717196-54a17ec2-8038-4a87-acbd-ed12badbf3a2.png">

> NOTE: Those errors are all just from Lucky No route (spam requests)

2 Servers will low resource usage

<img width="608" alt="Screenshot 2022-10-08 at 18 29 18" src="https://user-images.githubusercontent.com/7118473/194717280-9ae2bdf6-df05-48ea-aeda-2880acc9ed86.png">

