### PR TITLE
Dropping support for Crystal versions < 1.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,9 @@ jobs:
         shard_file:
           - shard.yml
         crystal_version:
-          - 1.0.0
-          - 1.1.1
-          - 1.2.2
-          - 1.3.2
           - 1.4.0
+          - 1.5.0
+          - 1.6.0
           - latest
     runs-on: ubuntu-latest
     container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
@@ -36,9 +34,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache Crystal
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3
         with:
           path: ~/.cache/crystal
           key: ${{ runner.os }}-crystal

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal:1.2.2
+      image: crystallang/crystal:1.6.1
     steps:
       - uses: actions/checkout@v2
         with:

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.2
 authors:
   - Celso Fernandes <celso.fernandes@gmail.com>
 
-crystal: ">= 1.0.0, < 2.0.0"
+crystal: ">= 1.4.0"
 
 dependencies:
   tasker:

--- a/src/backend/redis/legacy/backend.cr
+++ b/src/backend/redis/legacy/backend.cr
@@ -19,7 +19,6 @@ end
 
 module Cable
   class Backend < Cable::BackendCore
-
     getter redis_subscribe : Redis = Redis.new(url: Cable.settings.url)
     getter redis_publish : Redis::PooledClient | Redis do
       if Cable.settings.pool_redis_publish


### PR DESCRIPTION
This just updates actions and makes sure we're only supporting Crystal 1.4 or later. 

Ref: https://github.com/cable-cr/cable/pull/57