### PR TITLE
Adding a new DevBackend for testing.

### DIFF
--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include RequestHelpers
+
 describe Cable::Connection do
   it "removes the connection channel on close" do
     connect do |connection, _socket|
@@ -467,37 +469,6 @@ describe Cable::Connection do
       socket_1.close
       socket_2.close
     end
-  end
-end
-
-def builds_request(token : String) : HTTP::Request
-  headers = HTTP::Headers{
-    "Upgrade"                => "websocket",
-    "Connection"             => "Upgrade",
-    "Sec-WebSocket-Key"      => "OqColdEJm3i9e/EqMxnxZw==",
-    "Sec-WebSocket-Protocol" => "actioncable-v1-json, actioncable-unsupported",
-    "Sec-WebSocket-Version"  => "13",
-  }
-  HTTP::Request.new("GET", "#{Cable.settings.route}?test_token=#{token}", headers)
-end
-
-def builds_request(token : Nil) : HTTP::Request
-  headers = HTTP::Headers{
-    "Upgrade"                => "websocket",
-    "Connection"             => "Upgrade",
-    "Sec-WebSocket-Key"      => "OqColdEJm3i9e/EqMxnxZw==",
-    "Sec-WebSocket-Protocol" => "actioncable-v1-json, actioncable-unsupported",
-    "Sec-WebSocket-Version"  => "13",
-  }
-  HTTP::Request.new("GET", Cable.settings.route, headers)
-end
-
-private class DummySocket < HTTP::WebSocket
-  getter messages : Array(String) = Array(String).new
-
-  def send(message)
-    return if closed?
-    @messages << message
   end
 end
 

--- a/spec/cable/dev_backend_spec.cr
+++ b/spec/cable/dev_backend_spec.cr
@@ -1,0 +1,16 @@
+require "../spec_helper"
+
+include RequestHelpers
+
+describe Cable::DevBackend do
+  it "stores the broadcast" do
+    # This is required because the RedisBackend is
+    # configured by default and memoized
+    Cable.reset_server
+    Cable.temp_config(backend_class: Cable::DevBackend) do
+      ChatChannel.broadcast_to("chat_party", "Yo yo!")
+
+      Cable::DevBackend.published_messages.should contain({"chat_party", "Yo yo!"})
+    end
+  end
+end

--- a/spec/cable/dev_backend_spec.cr
+++ b/spec/cable/dev_backend_spec.cr
@@ -1,7 +1,5 @@
 require "../spec_helper"
 
-include RequestHelpers
-
 describe Cable::DevBackend do
   it "stores the broadcast" do
     # This is required because the RedisBackend is

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,7 +1,10 @@
 require "spec"
 require "../src/cable"
 require "../src/backend/redis/backend"
+require "../src/backend/dev/backend"
 require "./support/fake_exception_service"
+require "./support/request_helpers"
+require "./support/dummy_socket"
 require "./support/application_cable/connection"
 require "./support/application_cable/channel"
 require "./support/channels/*"
@@ -19,4 +22,5 @@ end
 Spec.before_each do
   Cable.restart
   FakeExceptionService.clear
+  Cable::DevBackend.reset
 end

--- a/spec/support/dummy_socket.cr
+++ b/spec/support/dummy_socket.cr
@@ -1,0 +1,8 @@
+class DummySocket < HTTP::WebSocket
+  getter messages : Array(String) = Array(String).new
+
+  def send(message)
+    return if closed?
+    @messages << message
+  end
+end

--- a/spec/support/request_helpers.cr
+++ b/spec/support/request_helpers.cr
@@ -1,0 +1,23 @@
+module RequestHelpers
+  def builds_request(token : String) : HTTP::Request
+    headers = HTTP::Headers{
+      "Upgrade"                => "websocket",
+      "Connection"             => "Upgrade",
+      "Sec-WebSocket-Key"      => "OqColdEJm3i9e/EqMxnxZw==",
+      "Sec-WebSocket-Protocol" => "actioncable-v1-json, actioncable-unsupported",
+      "Sec-WebSocket-Version"  => "13",
+    }
+    HTTP::Request.new("GET", "#{Cable.settings.route}?test_token=#{token}", headers)
+  end
+
+  def builds_request(token : Nil) : HTTP::Request
+    headers = HTTP::Headers{
+      "Upgrade"                => "websocket",
+      "Connection"             => "Upgrade",
+      "Sec-WebSocket-Key"      => "OqColdEJm3i9e/EqMxnxZw==",
+      "Sec-WebSocket-Protocol" => "actioncable-v1-json, actioncable-unsupported",
+      "Sec-WebSocket-Version"  => "13",
+    }
+    HTTP::Request.new("GET", Cable.settings.route, headers)
+  end
+end

--- a/src/backend/dev/backend.cr
+++ b/src/backend/dev/backend.cr
@@ -1,0 +1,47 @@
+module Cable
+  class DevBackend < Cable::BackendCore
+    # Store the published `stream_identifier` and `message`
+    class_getter published_messages = [] of Tuple(String, String)
+
+    # Store the `stream_identifier` on `subscribe`
+    class_getter subscriptions = [] of String
+
+    def self.reset
+      @@published_messages.clear
+      @@subscriptions.clear
+    end
+
+    def publish_message(stream_identifier : String, message : String)
+      @@published_messages << {stream_identifier, message}
+    end
+
+    def subscribe_connection
+    end
+
+    def publish_connection
+    end
+
+    def close_subscribe_connection
+    end
+
+    def close_publish_connection
+    end
+
+    def open_subscribe_connection(channel)
+    end
+
+    def subscribe(stream_identifier : String)
+      @@subscriptions << stream_identifier
+    end
+
+    def unsubscribe(stream_identifier : String)
+      @@subscriptions.delete(stream_identifier)
+    end
+
+    def ping_redis_subscribe
+    end
+
+    def ping_redis_publish
+    end
+  end
+end

--- a/src/backend/redis/backend.cr
+++ b/src/backend/redis/backend.cr
@@ -1,5 +1,5 @@
 module Cable
-  class Backend < Cable::BackendCore
+  class RedisBackend < Cable::BackendCore
     # connection management
     getter redis_subscribe : Redis::Connection = Redis::Connection.new(URI.parse(Cable.settings.url))
     getter redis_publish : Redis::Client = Redis::Client.new(URI.parse(Cable.settings.url))

--- a/src/backend/redis/legacy/backend.cr
+++ b/src/backend/redis/legacy/backend.cr
@@ -21,7 +21,8 @@
 
   module Cable
     # :nodoc:
-    class Backend < Cable::BackendCore
+    @[Deprecated("The RedisLegacyBackend will be removed in a future version")]
+    class RedisLegacyBackend < Cable::BackendCore
       getter redis_subscribe : Redis = Redis.new(url: Cable.settings.url)
       getter redis_publish : Redis::PooledClient | Redis do
         if Cable.settings.pool_redis_publish

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -31,6 +31,12 @@ module Cable
     setting token : String = "token", example: "token"
     setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
     setting disable_sec_websocket_protocol_header : Bool = false
+    setting backend_class : Cable::BackendCore.class = Cable::RedisBackend, example: "Cable::RedisBackend"
+    setting redis_ping_interval : Time::Span = 15.seconds
+    setting restart_error_allowance : Int32 = 20
+    setting on_error : Proc(Exception, String, Nil) = ->(exception : Exception, message : String) do
+      Cable::Logger.error(exception: exception) { message }
+    end
 
     # DEPRECATED
     # only use if you are using stefanwille/crystal-redis
@@ -38,11 +44,6 @@ module Cable
     setting pool_redis_publish : Bool = false
     setting redis_pool_size : Int32 = 5
     setting redis_pool_timeout : Float64 = 5.0
-    setting redis_ping_interval : Time::Span = 15.seconds
-    setting restart_error_allowance : Int32 = 20
-    setting on_error : Proc(Exception, String, Nil) = ->(exception : Exception, message : String) do
-      Cable::Logger.error(exception: exception) { message }
-    end
   end
 
   def self.message(event : Symbol)

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -8,6 +8,10 @@ module Cable
     @@server ||= Server.new
   end
 
+  def self.reset_server
+    @@server = nil
+  end
+
   def self.restart
     if current_server = @@server
       current_server.shutdown
@@ -25,8 +29,8 @@ module Cable
     getter pinger : Cable::RedisPinger do
       Cable::RedisPinger.new(self)
     end
-    getter backend do
-      Cable::Backend.new
+    getter backend : Cable::BackendCore do
+      Cable.settings.backend_class.new
     end
     getter backend_publish do
       backend.publish_connection


### PR DESCRIPTION
Fixes #61

This PR adds in a new `Cable::DevBackend` class that can be used for testing to ensure that your channels are called when you expect.

In order to do this, I had to rename the current Backend classes because they were both named `Cable::Backend`, and that wouldn't let you figure out if you were using redis or just this in-memory dev backend. We will need the separate naming anyway in order to do https://github.com/cable-cr/cable/issues/49 eventually.

I ended up moving some code from the `connection_spec.cr` in to helpers because as I was writing my spec, I thought I needed them, but turns out I didn't. I figure they belong in the spec/support anyway.

Lastly, in order to test, this requires setting the `@@server` in Cable to nil because we were calling `Cable.restart` before every spec. When that's called, `Cable.server` is defaulted to the Redis backend, and I need the DevBackend for my spec. 

This also means that potentially other devs will need to do the same... I'm not a huge fan of that, but I also don't know another way to handle that. 

This is a small breaking change for those that are using the legacy redis backend. If you are, you'll have to set `settings.backend_class = Cable::RedisLegacyBackend` in your Cable config for it to still work. This is officially deprecated now.