### PR TITLE
Better handling of malformed messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - crystal_version: nightly
             experimental: true
     runs-on: ubuntu-latest
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
+    container: crystallang/crystal:${{ matrix.crystal_version }}
     continue-on-error: ${{ matrix.experimental }}
     services:
       redis:

--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -11,6 +11,37 @@ describe Cable::Connection do
     ConnectionTest::CHANNELS.keys.size.should eq(0)
   end
 
+  describe "#receive" do
+    it "ignores empty messages" do
+      connect do |connection, socket|
+        connection.receive("")
+        sleep 0.1
+
+        socket.messages.size.should eq(0)
+
+        connection.close
+        socket.close
+      end
+    end
+
+    it "ignores incorrect json structures" do
+      connect do |connection, socket|
+        # The handler handles exception catching
+        # so we just make sure the correct exception is thrown
+        expect_raises(JSON::SerializableError) do
+          connection.receive([{command: "subscribe"}].to_json)
+        end
+
+        sleep 0.1
+
+        socket.messages.size.should eq(0)
+
+        connection.close
+        socket.close
+      end
+    end
+  end
+
   describe "#subscribe" do
     it "accepts" do
       connect do |connection, socket|

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -129,7 +129,7 @@ describe Cable::Handler do
 
       FakeExceptionService.size.should eq(1)
       FakeExceptionService.exceptions.first.keys.first.should eq("Cable::Handler#socket.on_message")
-      FakeExceptionService.exceptions.first.values.first.class.should eq(KeyError)
+      FakeExceptionService.exceptions.first.values.first.class.should eq(JSON::SerializableError)
     end
 
     it "rejected" do

--- a/spec/cable/payload_spec.cr
+++ b/spec/cable/payload_spec.cr
@@ -11,9 +11,9 @@ describe Cable::Payload do
       }.to_json,
     }.to_json
 
-    payload = Cable::Payload.new(payload_json)
+    payload = Cable::Payload.from_json(payload_json)
     payload.command.should eq("subscribe")
-    payload.identifier.should eq({channel: "ChatChannel", person: {name: "Foo", age: 32, boom: "boom"}, foo: "bar"}.to_json)
+    payload.identifier.key.should eq({channel: "ChatChannel", person: {name: "Foo", age: 32, boom: "boom"}, foo: "bar"}.to_json)
     payload.channel.should eq("ChatChannel")
     payload.channel_params.should eq({"person" => {"name" => "Foo", "age" => 32, "boom" => "boom"}, "foo" => "bar"})
   end
@@ -27,9 +27,9 @@ describe Cable::Payload do
       data: {invite_id: 3, action: "invite"}.to_json,
     }.to_json
 
-    payload = Cable::Payload.new(payload_json)
+    payload = Cable::Payload.from_json(payload_json)
     payload.command.should eq("message")
-    payload.identifier.should eq({channel: "ChatChannel"}.to_json)
+    payload.identifier.key.should eq({channel: "ChatChannel"}.to_json)
     payload.channel.should eq("ChatChannel")
     payload.data.should eq({"invite_id" => 3})
     payload.action?.should be_truthy

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -41,7 +41,7 @@ module Cable
         socket.on_message do |message|
           begin
             connection.receive(message)
-          rescue e : KeyError | JSON::ParseException
+          rescue e : KeyError | JSON::ParseException | JSON::SerializableError
             # handle unknown/malformed messages
             socket.close(HTTP::WebSocket::CloseCode::InvalidFramePayloadData, "Invalid message")
             Cable.server.remove_connection(connection_id)

--- a/src/cable/payload.cr
+++ b/src/cable/payload.cr
@@ -1,82 +1,118 @@
 module Cable
-  class Payload
+  struct Payload
+    include JSON::Serializable
+    include JSON::Serializable::Unmapped
     alias RESULT = String | Int64 | Hash(String, RESULT)
     alias PARAMS = Hash(String, RESULT)
 
-    getter json : String
-    getter action : String
-    getter command : String?
-    getter identifier : String
-    getter channel : String?
-    getter channel_params : Hash(String, Cable::Payload::RESULT) = Hash(String, RESULT).new
-    getter data : Hash(String, Cable::Payload::RESULT) = Hash(String, RESULT).new
+    module IdentifierConverter
+      def self.from_json(value : JSON::PullParser) : Indentifier
+        key = value.read_string
+        i = Indentifier.from_json(key)
+        i.key = key
+        i
+      end
 
-    def initialize(@json : String)
-      @parsed_json = JSON.parse(@json)
-      @action = ""
-      @is_action = false
-      @command = @parsed_json["command"].as_s
-      @identifier = @parsed_json["identifier"].as_s
-      @channel = process_channel
-      @channel_params = process_channel_params
-      @data = process_data
-    end
-
-    def action?
-      @is_action
-    end
-
-    private def parsed_identifier
-      JSON.parse(@parsed_json["identifier"].as_s)
-    end
-
-    private def process_channel
-      parsed_identifier["channel"].as_s
-    end
-
-    private def json_data
-      JSON.parse(@parsed_json["data"].as_s) if @parsed_json.as_h.has_key?("data")
-    end
-
-    private def process_data
-      if jsd = json_data
-        params = jsd.as_h.dup
-        if deleted_action = params.delete("action")
-          @action = deleted_action.as_s
-          @is_action = true
-        end
-
-        process_hash(params)
-      else
-        Hash(String, RESULT).new
+      def self.to_json(value : Indentifier, json : JSON::Builder) : Nil
+        json.string(value.to_json)
       end
     end
 
-    private def process_channel_params
-      params = parsed_identifier.as_h.dup
-      params.delete("channel")
+    struct Indentifier
+      include JSON::Serializable
+      include JSON::Serializable::Unmapped
 
-      process_hash(params)
+      property channel : String
+
+      # This is the original JSON used to parse this
+      # It's used as a unique key to map the different channels
+      @[JSON::Field(ignore: true)]
+      property key : String = ""
+    end
+
+    @[JSON::Field]
+    getter command : String
+
+    @[JSON::Field(converter: Cable::Payload::IdentifierConverter)]
+    getter identifier : Indentifier
+
+    @[JSON::Field(ignore: true)]
+    getter action : String = ""
+
+    # After the Payload is deserialized, parse the data.
+    # This will ensure we know if it's an action.
+    def after_initialize
+      data
+    end
+
+    def channel : String
+      identifier.channel
+    end
+
+    def action? : Bool
+      !action.presence.nil?
+    end
+
+    @[JSON::Field(ignore: true)]
+    @_channel_params : Hash(String, RESULT)? = nil
+
+    # These are the additional data sent with the identifier
+    # e.g. `{channel: "RoomChannel", room_id: 1}`
+    # ```
+    # channel_params["room_id"] # => 1
+    # ```
+    def channel_params : Hash(String, RESULT)
+      if @_channel_params.nil?
+        @_channel_params = process_hash(identifier.json_unmapped)
+      else
+        @_channel_params.as(Hash(String, RESULT))
+      end
+    end
+
+    @[JSON::Field(ignore: true)]
+    @_data : Hash(String, RESULT)? = nil
+
+    def data : Hash(String, RESULT)
+      if @_data.nil?
+        if unmapped_data = json_unmapped["data"]?
+          @_data = process_data(unmapped_data.as_s)
+        else
+          @_data = no_data
+        end
+      else
+        @_data.as(Hash(String, RESULT))
+      end
+    end
+
+    private def no_data : Hash(String, RESULT)
+      Hash(String, RESULT).new
+    end
+
+    private def process_hash(_params : Nil)
+      no_data
     end
 
     private def process_hash(params : Hash(String, JSON::Any))
       params_result = Hash(String, RESULT).new
 
       params.each do |k, v|
-        if v.as_s?
-          params_result[k] = v.as_s
-        elsif v.as_i64?
-          params_result[k] = v.as_i64
-        elsif v.as_h?
-          params_result[k] = process_hash(v)
+        if strval = v.as_s?
+          params_result[k] = strval
+        elsif intval = v.as_i64?
+          params_result[k] = intval
+        elsif hshval = v.as_h?
+          params_result[k] = process_hash(hshval)
         end
       end
 
       params_result
     end
 
-    private def process_hash(hash : JSON::Any)
-      process_hash(hash.as_h)
+    private def process_data(data_string : String)
+      json_data = JSON.parse(data_string).as_h?
+      hash = process_hash(json_data)
+      @action = hash.delete("action").to_s
+      hash
     end
   end
 end

--- a/src/cable/payload.cr
+++ b/src/cable/payload.cr
@@ -14,7 +14,7 @@ module Cable
       end
 
       def self.to_json(value : Indentifier, json : JSON::Builder) : Nil
-        json.string(value.to_json)
+        json.string(value.key)
       end
     end
 


### PR DESCRIPTION
Fixes #67

This PR refactors how the `Payload` is created in order to better handle when a message comes through with malformed data. It also gives us a bit of a performance boost by moving the Payload over to structs!

```
❯ ./bench 
new_payload 677.95  (  1.48ms) (± 5.55%)  2.92MB/op        fastest
old_payload 513.67  (  1.95ms) (± 5.67%)  4.37MB/op   1.32× slower
```

### Explanation

The current `Payload` makes a lot of assumptions about the shape of the JSON being parsed. It first assumes valid JSON is passed in, then assumes that the valid JSON is an Object. The handler generally just does a blanket JSON::ParsingError catch on this.

Now if we get an empty string, we can just ignore it, and if the JSON structure is valid, it'll be a full serialized object we can pass around easier. If the Payload can't be deserialized, then we raise the serialized error and let the handler do as it does.
