### PR TITLE
Catch when unmapped data is passed with the wrong type. 

### DIFF
--- a/spec/cable/payload_spec.cr
+++ b/spec/cable/payload_spec.cr
@@ -35,4 +35,19 @@ describe Cable::Payload do
     payload.action?.should be_truthy
     payload.action.should eq("invite")
   end
+
+  it "raises a SerializableError when the identifier is not a string" do
+    payload_json = {
+      command:    "subscribe",
+      identifier: {
+        channel: "ChatChannel",
+        person:  {name: "Foo", age: 32, boom: "boom"},
+        foo:     "bar",
+      },
+    }.to_json
+
+    expect_raises(JSON::SerializableError) do
+      Cable::Payload.from_json(payload_json)
+    end
+  end
 end

--- a/src/cable/payload.cr
+++ b/src/cable/payload.cr
@@ -74,8 +74,8 @@ module Cable
 
     def data : Hash(String, RESULT)
       if @_data.nil?
-        if unmapped_data = json_unmapped["data"]?
-          @_data = process_data(unmapped_data.as_s)
+        if unmapped_data = json_unmapped["data"]?.try(&.as_s?)
+          @_data = process_data(unmapped_data)
         else
           @_data = no_data
         end


### PR DESCRIPTION
Ref #67

I missed this line in the last PR. If you send the identifier with extra data, but not as a `String`, then the exception would be a typecast error which isn't caught by the websocket handler. If we can't typecast to a String, then no identifier is created, and a `JSON::SerializableError` error is raised which will be caught by the handler to reject the connection