### PR TITLE
Adding in a way to disconnect a connection remotely.

### DIFF
--- a/src/cable.cr
+++ b/src/cable.cr
@@ -21,6 +21,7 @@ module Cable
       unauthorized:    "unauthorized",
       invalid_request: "invalid_request",
       server_restart:  "server_restart",
+      remote:          "remote",
     },
     default_mount_path: "/cable",
     protocols:          ["actioncable-v1-json", "actioncable-unsupported"],

--- a/src/cable/remote_connections.cr
+++ b/src/cable/remote_connections.cr
@@ -1,0 +1,31 @@
+module Cable
+  class RemoteConnections
+    def initialize(@server : Cable::Server)
+    end
+
+    # Specify the name and value of your connection's `identified_by`
+    # ```
+    # # e.g.
+    # # identified_by :user_id
+    # # self.user_id = 1234.to_s
+    #
+    # where({:user_id, "1234"})
+    # ```
+    def where(identifier : Tuple(Symbol, String))
+      RemoteConnection.new(@server, identifier[1])
+    end
+
+    private class RemoteConnection
+      def initialize(@server : Cable::Server, @value : String)
+      end
+
+      def disconnect
+        @server.backend.publish_message(internal_channel, Cable.message(:disconnect))
+      end
+
+      private def internal_channel
+        "cable_internal/#{@value}"
+      end
+    end
+  end
+end

--- a/src/cable/remote_connections.cr
+++ b/src/cable/remote_connections.cr
@@ -3,16 +3,16 @@ module Cable
     def initialize(@server : Cable::Server)
     end
 
-    # Specify the name and value of your connection's `identified_by`
+    # Specify the value of your connection's `identified_by`
     # ```
     # # e.g.
     # # identified_by :user_id
     # # self.user_id = 1234.to_s
     #
-    # where({:user_id, "1234"})
+    # find("1234")
     # ```
-    def where(identifier : Tuple(Symbol, String))
-      RemoteConnection.new(@server, identifier[1])
+    def find(identifier : String)
+      RemoteConnection.new(@server, identifier)
     end
 
     private class RemoteConnection

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -135,7 +135,7 @@ module Cable
     def send_to_internal_channels(channel_identifier : String, message : String)
       if internal_channel = @_internal_subscriptions[channel_identifier]?
         case message
-        when "disconnect"
+        when Cable.message(:disconnect)
           Cable::Logger.info { "Removing connection (#{channel_identifier})" }
           internal_channel.close
         end
@@ -182,7 +182,7 @@ module Cable
       spawn(name: "Cable::Server - process_subscribed_messages") do
         while received = fiber_channel.receive
           channel, message = received
-          if channel.includes?("cable_internal") && message == Cable.message(:disconnect)
+          if channel.includes?("cable_internal")
             server.send_to_internal_channels(channel, message)
           else
             server.send_to_channels(channel, message)


### PR DESCRIPTION
Fixes #42

This PR adds in the ability to disconnect a connection remotely which is similar to the Rails ActionCable [RemoteConnections](https://api.rubyonrails.org/classes/ActionCable/RemoteConnections.html)

Currently this is still missing the ability to pass an auto reconnect. That may need to come in a future PR.

For this to work, your connections must use the `identified_by`.

```crystal
module ApplicationCable
  class Connection < Cable::Connection
    identified_by :identifier

    def connect
      self.identifier = "some-id-or-token"
    end
  end
end
```

Then if you need to disconnect that socket, you can use

```crystal
Cable.server.remote_connections.where({:identifier, "some-id-or-token"}).disconnect
```

This is fairly close to how it works with ActionCable, except for with ActionCable, you can do stuff like

```ruby
identified_by :current_user

def connect
  self.current_user = User.first
end
```

Then Rails handles doing the magic of turning a `User` object in to some String value. It also lets you pass in key value pairs which turned them in to instance vars https://github.com/rails/rails/blob/e9ea600c24bb44317cf6176c34020a7d0e1060f3/actioncable/lib/action_cable/remote_connections.rb#L71 and I'm not really sure why :thinking: 

For now I'll leave in Draft to allow some people to look over it, and I need to figure out how to write some specs for all this.