### PR TITLE
Refactor remote connections

### DIFF
--- a/spec/cable/server_spec.cr
+++ b/spec/cable/server_spec.cr
@@ -1,0 +1,17 @@
+require "../spec_helper"
+
+include RequestHelpers
+
+describe Cable::Server do
+  describe "#remote_connections" do
+    it "finds the connection and disconnects it" do
+      Cable.reset_server
+      Cable.temp_config(backend_class: Cable::DevBackend) do
+        connect do |connection, _socket|
+          Cable.server.remote_connections.find(connection.connection_identifier).disconnect
+          Cable::DevBackend.published_messages.should contain({"cable_internal/#{connection.connection_identifier}", "disconnect"})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #75

This is an attempt to clean up how the internal subscriptions are handled. Now it will use the `connection_identifier` instead of the `internal_identifier`. This is because the Server was already storing a Hash of connections where the key is the `connection_identifier`. The `@_internal_subscriptions` was only being used as a way to have access to the `internal_identifier`, but this duplicated each socket instance and wasn't being cleaned up properly. 

The upside to this is it shouldn't be using any more memory than it was prior to #71. The downside is that in order to disconnect a connection remotely, you will have to store the `connection_identifier` value externally somewhere. Each time a connection is made, that value is different due to the `UUID.random`.

Alternatively, since the `connection_identifier` always starts with the `internal_identifier`, we could in theory use that. However, that would mean the lookup would be a bit ugly doing something like...

```crystal
private class RemoteConnection
  @value : String
  def initialize(@server : Cable::Server, id : String)
    conn = @server.connections.find {|k, v| k.starts_with?(id) }
     @value = conn ? conn[0] : ""
  end
  #....
end
```

This is sort of pseudo code, but it would make the assumption that you would always pass in the `internal_identifier` value. Maybe that's ok? :man_shrugging: 