### PR TITLE
More memory leak tracking

### DIFF
--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -52,6 +52,14 @@ module Cable
       @connection_rejected = true
     end
 
+    def connection_accepted? : Bool
+      !connection_rejected?
+    end
+
+    def open? : Bool
+      !closed?
+    end
+
     def closed? : Bool
       socket.closed?
     end

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -52,14 +52,6 @@ module Cable
       @connection_rejected = true
     end
 
-    def connection_accepted? : Bool
-      !connection_rejected?
-    end
-
-    def open? : Bool
-      !closed?
-    end
-
     def closed? : Bool
       socket.closed?
     end

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -17,58 +17,63 @@ module Cable
 
       ws = HTTP::WebSocketHandler.new do |socket, ws_ctx|
         connection = T.new(ws_ctx.request, socket)
-        connection_id = connection.connection_identifier
 
-        # we should not add any connections which have been rejected
-        Cable.server.add_connection(connection) unless connection.connection_rejected?
+        if connection.open? && connection.connection_accepted?
+          connection_id = connection.connection_identifier
 
-        # Send welcome message to the client
-        socket.send({type: Cable.message(:welcome)}.to_json)
+          # we should not add any connections which have been rejected
+          Cable.server.add_connection(connection)
 
-        ws_pinger = Cable::WebsocketPinger.build(socket)
+          # Send welcome message to the client
+          socket.send({type: Cable.message(:welcome)}.to_json)
 
-        socket.on_ping do
-          socket.pong ws_ctx.request.path
-          Cable::Logger.debug { "Ping received" }
-        end
+          ws_pinger = Cable::WebsocketPinger.build(socket)
 
-        # Handle incoming message and echo back to the client
-        #
-        # **Exceptions**
-        # turns out, if you close socket in this block
-        # the socket.on_close blocked is not called 100% of the time
-        # so we need to do it manually
-        socket.on_message do |message|
-          begin
-            connection.receive(message)
-          rescue e : KeyError | JSON::ParseException | JSON::SerializableError
-            # handle unknown/malformed messages
-            socket.close(HTTP::WebSocket::CloseCode::InvalidFramePayloadData, "Invalid message")
-            Cable.server.remove_connection(connection_id)
-            Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
-          rescue e : Cable::Connection::UnathorizedConnectionException
-            # handle unauthorized connections
-            # no need to log them
-            socket.close(HTTP::WebSocket::CloseCode::NormalClosure, "Farewell")
-            # most of the time, we will have already removed the connection
-            # since the connection is rejected before any messages are received
-            # but just in case, we will try remove it anyways
-            Cable.server.remove_connection(connection_id)
-          rescue e : Exception
-            # handle all other exceptions
-            socket.close(HTTP::WebSocket::CloseCode::InternalServerError, "Internal Server Error")
-            Cable.server.remove_connection(connection_id)
-            # handle restart
-            Cable.server.count_error!
-            Cable.restart if Cable.server.restart?
-            Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
+          socket.on_ping do
+            socket.pong ws_ctx.request.path
+            Cable::Logger.debug { "Ping received" }
           end
-        end
 
-        socket.on_close do
-          ws_pinger.stop
-          Cable.server.remove_connection(connection_id)
-          Cable::Logger.info { "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc}" }
+          # Handle incoming message and echo back to the client
+          #
+          # **Exceptions**
+          # turns out, if you close socket in this block
+          # the socket.on_close blocked is not called 100% of the time
+          # so we need to do it manually
+          socket.on_message do |message|
+            begin
+              connection.receive(message)
+            rescue e : KeyError | JSON::ParseException | JSON::SerializableError
+              # handle unknown/malformed messages
+              socket.close(HTTP::WebSocket::CloseCode::InvalidFramePayloadData, "Invalid message")
+              Cable.server.remove_connection(connection_id)
+              Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
+            rescue e : Cable::Connection::UnathorizedConnectionException
+              # handle unauthorized connections
+              # no need to log them
+              socket.close(HTTP::WebSocket::CloseCode::NormalClosure, "Farewell")
+              # most of the time, we will have already removed the connection
+              # since the connection is rejected before any messages are received
+              # but just in case, we will try remove it anyways
+              Cable.server.remove_connection(connection_id)
+            rescue e : Exception
+              # handle all other exceptions
+              socket.close(HTTP::WebSocket::CloseCode::InternalServerError, "Internal Server Error")
+              Cable.server.remove_connection(connection_id)
+              # handle restart
+              Cable.server.count_error!
+              Cable.restart if Cable.server.restart?
+              Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
+            end
+          end
+
+          socket.on_close do
+            ws_pinger.stop
+            Cable.server.remove_connection(connection_id)
+            Cable::Logger.info { "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc}" }
+          end
+        else
+          next
         end
       rescue e : Exception
         Cable.settings.on_error.call(e, "Cable::Handler#call -> HTTP::WebSocketHandler")

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -18,62 +18,59 @@ module Cable
       ws = HTTP::WebSocketHandler.new do |socket, ws_ctx|
         connection = T.new(ws_ctx.request, socket)
 
-        if connection.open? && connection.connection_accepted?
-          connection_id = connection.connection_identifier
+        next if connection.closed? || connection.connection_rejected?
+        connection_id = connection.connection_identifier
 
-          # we should not add any connections which have been rejected
-          Cable.server.add_connection(connection)
+        # we should not add any connections which have been rejected
+        Cable.server.add_connection(connection)
 
-          # Send welcome message to the client
-          socket.send({type: Cable.message(:welcome)}.to_json)
+        # Send welcome message to the client
+        socket.send({type: Cable.message(:welcome)}.to_json)
 
-          ws_pinger = Cable::WebsocketPinger.build(socket)
+        ws_pinger = Cable::WebsocketPinger.build(socket)
 
-          socket.on_ping do
-            socket.pong ws_ctx.request.path
-            Cable::Logger.debug { "Ping received" }
-          end
+        socket.on_ping do
+          socket.pong ws_ctx.request.path
+          Cable::Logger.debug { "Ping received" }
+        end
 
-          # Handle incoming message and echo back to the client
-          #
-          # **Exceptions**
-          # turns out, if you close socket in this block
-          # the socket.on_close blocked is not called 100% of the time
-          # so we need to do it manually
-          socket.on_message do |message|
-            begin
-              connection.receive(message)
-            rescue e : KeyError | JSON::ParseException | JSON::SerializableError
-              # handle unknown/malformed messages
-              socket.close(HTTP::WebSocket::CloseCode::InvalidFramePayloadData, "Invalid message")
-              Cable.server.remove_connection(connection_id)
-              Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
-            rescue e : Cable::Connection::UnathorizedConnectionException
-              # handle unauthorized connections
-              # no need to log them
-              socket.close(HTTP::WebSocket::CloseCode::NormalClosure, "Farewell")
-              # most of the time, we will have already removed the connection
-              # since the connection is rejected before any messages are received
-              # but just in case, we will try remove it anyways
-              Cable.server.remove_connection(connection_id)
-            rescue e : Exception
-              # handle all other exceptions
-              socket.close(HTTP::WebSocket::CloseCode::InternalServerError, "Internal Server Error")
-              Cable.server.remove_connection(connection_id)
-              # handle restart
-              Cable.server.count_error!
-              Cable.restart if Cable.server.restart?
-              Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
-            end
-          end
-
-          socket.on_close do
-            ws_pinger.stop
+        # Handle incoming message and echo back to the client
+        #
+        # **Exceptions**
+        # turns out, if you close socket in this block
+        # the socket.on_close blocked is not called 100% of the time
+        # so we need to do it manually
+        socket.on_message do |message|
+          begin
+            connection.receive(message)
+          rescue e : KeyError | JSON::ParseException | JSON::SerializableError
+            # handle unknown/malformed messages
+            socket.close(HTTP::WebSocket::CloseCode::InvalidFramePayloadData, "Invalid message")
             Cable.server.remove_connection(connection_id)
-            Cable::Logger.info { "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc}" }
+            Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
+          rescue e : Cable::Connection::UnathorizedConnectionException
+            # handle unauthorized connections
+            # no need to log them
+            socket.close(HTTP::WebSocket::CloseCode::NormalClosure, "Farewell")
+            # most of the time, we will have already removed the connection
+            # since the connection is rejected before any messages are received
+            # but just in case, we will try remove it anyways
+            Cable.server.remove_connection(connection_id)
+          rescue e : Exception
+            # handle all other exceptions
+            socket.close(HTTP::WebSocket::CloseCode::InternalServerError, "Internal Server Error")
+            Cable.server.remove_connection(connection_id)
+            # handle restart
+            Cable.server.count_error!
+            Cable.restart if Cable.server.restart?
+            Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
           end
-        else
-          next
+        end
+
+        socket.on_close do
+          ws_pinger.stop
+          Cable.server.remove_connection(connection_id)
+          Cable::Logger.info { "Finished \"#{path}\" [WebSocket] for #{remote_address} at #{Time.utc}" }
         end
       rescue e : Exception
         Cable.settings.on_error.call(e, "Cable::Handler#call -> HTTP::WebSocketHandler")

--- a/src/cable/redis_pinger.cr
+++ b/src/cable/redis_pinger.cr
@@ -9,7 +9,7 @@ module Cable
         @server.backend.ping_redis_subscribe
         @server.backend.ping_redis_publish
       rescue e
-        next stop
+        stop
         Cable::Logger.error { "Cable::RedisPinger Exception: #{e.class.name} -> #{e.message}" }
         # Restart cable if something happened
         Cable.server.count_error!

--- a/src/cable/redis_pinger.cr
+++ b/src/cable/redis_pinger.cr
@@ -9,6 +9,7 @@ module Cable
         @server.backend.ping_redis_subscribe
         @server.backend.ping_redis_publish
       rescue e
+        next stop
         Cable::Logger.error { "Cable::RedisPinger Exception: #{e.class.name} -> #{e.message}" }
         # Restart cable if something happened
         Cable.server.count_error!

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -40,17 +40,22 @@ module Cable
       backend.subscribe_connection
     end
 
-    @channels = {} of String => Channels
-    @channel_mutex = Mutex.new
+    @channels : Hash(String, Channels)
+    @channel_mutex : Mutex
 
     def initialize
-      # load the connections
-      backend
-      subscribe
-      process_subscribed_messages
-    rescue e
-      Cable.settings.on_error.call(e, "Cable::Server.initialize")
-      raise e
+      @channels = {} of String => Channels
+      @channel_mutex = Mutex.new
+
+      begin
+        # load the connections
+        backend
+        subscribe
+        process_subscribed_messages
+      rescue e
+        Cable.settings.on_error.call(e, "Cable::Server.initialize")
+        raise e
+      end
     end
 
     def remote_connections

--- a/src/cable/websocket_pinger.cr
+++ b/src/cable/websocket_pinger.cr
@@ -2,8 +2,6 @@ require "tasker"
 
 module Cable
   class WebsocketPinger
-    class PingStoppedException < Exception; end
-
     @@seconds : Int32 | Float64 = 3
     @task : Tasker::Task
 
@@ -25,12 +23,12 @@ module Cable
 
     def initialize(@socket : HTTP::WebSocket)
       @task = Tasker.every(Cable::WebsocketPinger.seconds.seconds) do
-        raise PingStoppedException.new("Stopped") if @socket.closed?
+        next stop if @socket.closed?
         @socket.send({type: Cable.message(:ping), message: Time.utc.to_unix}.to_json)
       end
     end
 
-    def stop
+    def stop : Nil
       @task.cancel
     end
   end


### PR DESCRIPTION
Fixes #81

This PR mainly tracks down more memory leaks that may be caused by early socket closures. I believe what was happening is the websocket pinger would get a closed socket and raise, but that raise happened in a background future, and the tasker itself was never being stopped. There was also no use of calling `rescue PingStoppedException`, so that exception was just tossed away.

Secondly, if the socket was closed within the connection `initialize`, the handler never checked for this. We would call `socket.send({type: Cable.message(:welcome)}.to_json)` on a closed socket which just raises an `IO::Error`. When that happens, no additional cleanup from the server would take place.

I added some checks around closed sockets to ensure things are properly cleaned up.