### PR TITLE
Cable::Server#active_connections_for and Cable::Server#subscribed_channels_for public checkup methods

### DIFF
--- a/spec/cable/connection_spec.cr
+++ b/spec/cable/connection_spec.cr
@@ -3,12 +3,22 @@ require "../spec_helper"
 include RequestHelpers
 
 describe Cable::Connection do
-  it "removes the connection channel on close" do
-    connect do |connection, _socket|
-      connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
-      ConnectionTest::CHANNELS.keys.size.should eq(1)
+  describe "#close" do
+    it "closes the connection socket even without channel subscriptions" do
+      connect do |connection, _socket|
+        connection.closed?.should eq(false)
+        connection.close
+        connection.closed?.should eq(true)
+      end
     end
-    ConnectionTest::CHANNELS.keys.size.should eq(0)
+    it "removes the connection channel on close" do
+      connect do |connection, _socket|
+        connection.receive({"command" => "subscribe", "identifier" => {channel: "ChatChannel", room: "1"}.to_json}.to_json)
+        ConnectionTest::CHANNELS.keys.size.should eq(1)
+        connection.close
+        ConnectionTest::CHANNELS.keys.size.should eq(0)
+      end
+    end
   end
 
   describe "#receive" do

--- a/spec/cable/handler_spec.cr
+++ b/spec/cable/handler_spec.cr
@@ -50,6 +50,8 @@ describe Cable::Handler do
       ws2 = HTTP::WebSocket.new("ws://#{listen_address}/updates?test_token=1")
 
       Cable.server.connections.size.should eq(1)
+      Cable.server.active_connections_for("1").size.should eq(1)
+      Cable.server.subscribed_channels_for("1").size.should eq(0)
 
       messages = [
         {type: "welcome"}.to_json,
@@ -69,6 +71,8 @@ describe Cable::Handler do
       ws2.run
 
       Cable.server.connections.size.should eq(1)
+      Cable.server.active_connections_for("1").size.should eq(1)
+      Cable.server.subscribed_channels_for("1").size.should eq(1)
     end
 
     it "malformed data from client" do

--- a/spec/cable/server_spec.cr
+++ b/spec/cable/server_spec.cr
@@ -19,4 +19,37 @@ describe Cable::Server do
       end
     end
   end
+
+  describe "#active_connections_for" do
+    it "accurately returns active connections for a specificic token" do
+      Cable.reset_server
+      Cable.temp_config(backend_class: Cable::DevBackend) do
+        Cable.server.active_connections_for("abc123").size.should eq(0)
+        Cable.server.active_connections_for("def456").size.should eq(0)
+
+        socket = DummySocket.new(IO::Memory.new)
+        request = builds_request("abc123")
+        connection = ApplicationCable::Connection.new(request, socket)
+        Cable.server.add_connection(connection)
+
+        Cable.server.active_connections_for("abc123").size.should eq(1)
+
+        other_socket = DummySocket.new(IO::Memory.new)
+        other_request = builds_request("def456")
+        other_connection = ApplicationCable::Connection.new(other_request, other_socket)
+        Cable.server.add_connection(other_connection)
+
+        Cable.server.active_connections_for("def456").size.should eq(1)
+
+        connection.close
+
+        Cable.server.active_connections_for("abc123").size.should eq(0)
+        Cable.server.active_connections_for("def456").size.should eq(1)
+
+        other_connection.close
+
+        Cable.server.active_connections_for("def456").size.should eq(0)
+      end
+    end
+  end
 end

--- a/spec/cable/server_spec.cr
+++ b/spec/cable/server_spec.cr
@@ -7,9 +7,7 @@ describe Cable::Server do
     it "finds the connection and disconnects it" do
       Cable.reset_server
       Cable.temp_config(backend_class: Cable::DevBackend) do
-        socket = DummySocket.new(IO::Memory.new)
-        request = builds_request("abc123")
-        connection = ApplicationCable::Connection.new(request, socket)
+        connection = creates_new_connection("abc123")
         Cable.server.add_connection(connection)
         connection.connection_identifier.should contain("abc123")
 
@@ -27,16 +25,12 @@ describe Cable::Server do
         Cable.server.active_connections_for("abc123").size.should eq(0)
         Cable.server.active_connections_for("def456").size.should eq(0)
 
-        socket = DummySocket.new(IO::Memory.new)
-        request = builds_request("abc123")
-        connection = ApplicationCable::Connection.new(request, socket)
+        connection = creates_new_connection("abc123")
         Cable.server.add_connection(connection)
 
         Cable.server.active_connections_for("abc123").size.should eq(1)
 
-        other_socket = DummySocket.new(IO::Memory.new)
-        other_request = builds_request("def456")
-        other_connection = ApplicationCable::Connection.new(other_request, other_socket)
+        other_connection = creates_new_connection("def456")
         Cable.server.add_connection(other_connection)
 
         Cable.server.active_connections_for("def456").size.should eq(1)
@@ -52,4 +46,54 @@ describe Cable::Server do
       end
     end
   end
+
+  describe "#subscribed_channels_for" do
+    it "accurately returns active channel subscriptions for a specificic token" do
+      Cable.reset_server
+      Cable.temp_config(backend_class: Cable::DevBackend) do
+        connection_1 = creates_new_connection("aa")
+        connection_2 = creates_new_connection("bb")
+
+        Cable.server.add_connection(connection_1)
+        Cable.server.add_connection(connection_2)
+
+        Cable.server.subscribed_channels_for("aa").size.should eq(0)
+        Cable.server.subscribed_channels_for("bb").size.should eq(0)
+
+        connection_1.subscribe(subscribe_payload("room_a"))
+
+        Cable.server.subscribed_channels_for("aa").size.should eq(1)
+        Cable.server.subscribed_channels_for("bb").size.should eq(0)
+
+        connection_1.subscribe(subscribe_payload("room_b"))
+
+        Cable.server.subscribed_channels_for("aa").size.should eq(2)
+        Cable.server.subscribed_channels_for("bb").size.should eq(0)
+
+        connection_2.subscribe(subscribe_payload("room_a"))
+
+        Cable.server.subscribed_channels_for("aa").size.should eq(2)
+        Cable.server.subscribed_channels_for("bb").size.should eq(1)
+
+        connection_1.close
+        connection_2.close
+      end
+      Cable.reset_server
+    end
+  end
+end
+
+def creates_new_connection(token : String | Nil) : ApplicationCable::Connection
+  ApplicationCable::Connection.new(builds_request(token: token), DummySocket.new(IO::Memory.new))
+end
+
+def subscribe_payload(room : String) : Cable::Payload
+  payload_json = {
+    command:    "subscribe",
+    identifier: {
+      channel: "ChatChannel",
+      room:    room,
+    }.to_json,
+  }.to_json
+  Cable::Payload.from_json(payload_json)
 end

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -52,8 +52,8 @@ module Cable
       @connection_rejected = true
     end
 
-    def channels : Array(Channel)
-      return Array(Channel).new unless Connection::CHANNELS.has_key?(connection_identifier)
+    def channels : Array(Cable::Channel)
+      return Array(Cable::Channel).new unless Connection::CHANNELS.has_key?(connection_identifier)
       Connection::CHANNELS.[connection_identifier].values
     end
 

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -52,6 +52,10 @@ module Cable
       @connection_rejected = true
     end
 
+    def channels : Array(Channel)
+      Connection::CHANNELS[connection_identifier]
+    end
+
     def closed? : Bool
       socket.closed?
     end
@@ -75,7 +79,7 @@ module Cable
     end
 
     def send_message(message : String)
-      return if socket.closed?
+      return if closed?
 
       socket.send(message)
     end

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -53,7 +53,8 @@ module Cable
     end
 
     def channels : Array(Channel)
-      Connection::CHANNELS[connection_identifier]
+      return Array(Channel).new unless Connection::CHANNELS.has_key?(connection_identifier)
+      Connection::CHANNELS.[connection_identifier].values
     end
 
     def closed? : Bool

--- a/src/cable/connection.cr
+++ b/src/cable/connection.cr
@@ -2,7 +2,7 @@ require "uuid"
 
 module Cable
   abstract class Connection
-    class UnathorizedConnectionException < Exception; end
+    class UnauthorizedConnectionException < Exception; end
 
     property internal_identifier : String = "0"
     property connection_identifier : String = ""
@@ -38,7 +38,7 @@ module Cable
         # gather connection_identifier after the connection has gathered the id from identified_by(field)
         self.connection_identifier = "#{internal_identifier}-#{UUID.random}"
         subscribe_to_internal_channel
-      rescue e : UnathorizedConnectionException
+      rescue e : UnauthorizedConnectionException
         reject_connection!
         unsubscribe_from_internal_channel
         socket.close(HTTP::WebSocket::CloseCode::NormalClosure, "Farewell")
@@ -86,7 +86,7 @@ module Cable
     end
 
     def reject_unauthorized_connection
-      raise UnathorizedConnectionException.new
+      raise UnauthorizedConnectionException.new
     end
 
     # Convert the `message` to a proper `Payload`.

--- a/src/cable/handler.cr
+++ b/src/cable/handler.cr
@@ -49,7 +49,7 @@ module Cable
             socket.close(HTTP::WebSocket::CloseCode::InvalidFramePayloadData, "Invalid message")
             Cable.server.remove_connection(connection_id)
             Cable.settings.on_error.call(e, "Cable::Handler#socket.on_message")
-          rescue e : Cable::Connection::UnathorizedConnectionException
+          rescue e : Cable::Connection::UnauthorizedConnectionException
             # handle unauthorized connections
             # no need to log them
             ws_pinger.stop

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -70,10 +70,15 @@ module Cable
       connections.delete(connection_id).try(&.close)
     end
 
+    # You shouldn't rely on these two methods for an exhaustive array of connections
+    # if your application can spawn more than one Cable.server instance.
+
+    # Only returns connections opened on this instance.
     def active_connections_for(token : String) : Array(Connection)
       connections.values.select { |connection| connection.token == token && !connection.closed? }
     end
 
+    # Only returns channel subscriptions opened on this instance.
     def subscribed_channels_for(token : String) : Array(Channel)
       active_connections_for(token).sum { |connection| connection.channels }
     end

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -70,7 +70,8 @@ module Cable
       connections.delete(connection_id).try(&.close)
     end
 
-    # You shouldn't rely on these two methods for an exhaustive array of connections
+    # You shouldn't rely on these following two methods
+    # for an exhaustive array of connections and channels
     # if your application can spawn more than one Cable.server instance.
 
     # Only returns connections opened on this instance.

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -81,7 +81,7 @@ module Cable
 
     # Only returns channel subscriptions opened on this instance.
     def subscribed_channels_for(token : String) : Array(Channel)
-      active_connections_for(token).sum { |connection| connection.channels }
+      active_connections_for(token).sum(&.channels)
     end
 
     def subscribe_channel(channel : Channel, identifier : String)

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -70,6 +70,14 @@ module Cable
       connections.delete(connection_id).try(&.close)
     end
 
+    def active_connections_for(token : String) : Array(Connection)
+      connections.values.select { |connection| connection.token == token && !connection.closed? }
+    end
+
+    def subscribed_channels_for(token : String) : Array(Channel)
+      active_connections_for(token).map { |connection| connection.channels }
+    end
+
     def subscribe_channel(channel : Channel, identifier : String)
       @channel_mutex.synchronize do
         if !@channels.has_key?(identifier)
@@ -112,7 +120,7 @@ module Cable
         @channels[channel_identifier].each do |channel|
           # TODO: would be nice to have a test where we open two connections
           # close one, and make sure the other one receives the message
-          if channel.connection.socket.closed?
+          if channel.connection.closed?
             channel.close
           else
             Cable::Logger.info { "#{channel.class} transmitting #{parsed_message} (via streamed from #{channel.stream_identifier})" }

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -75,7 +75,7 @@ module Cable
     end
 
     def subscribed_channels_for(token : String) : Array(Channel)
-      active_connections_for(token).map { |connection| connection.channels }
+      active_connections_for(token).sum { |connection| connection.channels }
     end
 
     def subscribe_channel(channel : Channel, identifier : String)


### PR DESCRIPTION
From https://github.com/cable-cr/cable/issues/85, this is a draft proposal PR investigating the best way for the backend to check what connection / channel are active for a given token (ie user).

The maze of different `identifiers` must make me oblivious to a simpler (ie more efficient than a rough `#select == token`) way to get the info we need.

I've added some DRY suggestions.

Right now, this is a draft, it lacks proper specs.

I'm working to add them but if you have DX / code design remarks / etc. please tell, I'm really new to this codebase (and websockets in general) !