### PR TITLE
Big refactor to make the backend registerable and swappable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   specs:
     env:
-      REDIS_URL: redis://redis:6379
+      CABLE_BACKEND_URL: redis://redis:6379
     strategy:
       fail-fast: false
       matrix:
@@ -40,9 +40,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Crystal
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/crystal
           key: ${{ runner.os }}-crystal

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,7 +12,8 @@ require "./support/channels/*"
 Cable.configure do |settings|
   settings.route = "/updates"
   settings.token = "test_token"
-  settings.url = "redis://localhost:6379"
+  settings.url = ENV.fetch("CABLE_BACKEND_URL", "redis://localhost:6379")
+  settings.backend_class = Cable::RedisBackend
   settings.backend_ping_interval = 2.seconds
   settings.restart_error_allowance = 2
   settings.on_error = ->(exception : Exception, message : String) do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,7 +12,8 @@ require "./support/channels/*"
 Cable.configure do |settings|
   settings.route = "/updates"
   settings.token = "test_token"
-  settings.redis_ping_interval = 2.seconds
+  settings.url = "redis://localhost:6379"
+  settings.backend_ping_interval = 2.seconds
   settings.restart_error_allowance = 2
   settings.on_error = ->(exception : Exception, message : String) do
     FakeExceptionService.notify(exception, message: message)

--- a/src/backend/dev/backend.cr
+++ b/src/backend/dev/backend.cr
@@ -38,10 +38,10 @@ module Cable
       @@subscriptions.delete(stream_identifier)
     end
 
-    def ping_redis_subscribe
+    def ping_subscribe_connection
     end
 
-    def ping_redis_publish
+    def ping_publish_connection
     end
   end
 end

--- a/src/backend/redis/backend.cr
+++ b/src/backend/redis/backend.cr
@@ -1,5 +1,10 @@
+require "redis"
+
 module Cable
   class RedisBackend < Cable::BackendCore
+    register "redis"  # redis://
+    register "rediss" # rediss://
+
     # connection management
     getter redis_subscribe : Redis::Connection = Redis::Connection.new(URI.parse(Cable.settings.url))
     getter redis_publish : Redis::Client = Redis::Client.new(URI.parse(Cable.settings.url))
@@ -72,13 +77,13 @@ module Cable
     # then publish a special channel/message broadcast
     # the @server.redis_subscribe picks up this special combination
     # and calls ping on the block loop for us
-    def ping_redis_subscribe
+    def ping_subscribe_connection
       Cable.server.publish(Cable::INTERNAL[:channel], "ping")
     end
 
-    def ping_redis_publish
+    def ping_publish_connection
       result = redis_publish.run({"ping"})
-      Cable::Logger.debug { "Cable::RedisPinger.ping_redis_publish -> #{result}" }
+      Cable::Logger.debug { "Cable::BackendPinger.ping_publish_connection -> #{result}" }
     end
   end
 end

--- a/src/backend/redis/legacy/backend.cr
+++ b/src/backend/redis/legacy/backend.cr
@@ -106,15 +106,15 @@
 
       # ping/pong
 
-      def ping_redis_subscribe
+      def ping_subscribe_connection
         Cable.server.publish("_internal", "ping")
       end
 
-      def ping_redis_publish
+      def ping_publish_connection
         request = Redis::Request.new
         request << "ping"
         result = redis_subscribe._connection.send(request)
-        Cable::Logger.debug { "Cable::RedisPinger.ping_redis_publish -> #{result}" }
+        Cable::Logger.debug { "Cable::BackendPinger.ping_publish_connection -> #{result}" }
       end
     end
   end

--- a/src/cable.cr
+++ b/src/cable.cr
@@ -1,6 +1,5 @@
 require "habitat"
 require "json"
-require "redis"
 require "./cable/**"
 
 # TODO: Write documentation for `Cable`
@@ -30,10 +29,10 @@ module Cable
   Habitat.create do
     setting route : String = Cable.message(:default_mount_path), example: "/cable"
     setting token : String = "token", example: "token"
-    setting url : String = ENV.fetch("REDIS_URL", "redis://localhost:6379"), example: "redis://localhost:6379"
+    setting url : String = ENV["CABLE_BACKEND_URL"], example: "redis://localhost:6379"
     setting disable_sec_websocket_protocol_header : Bool = false
-    setting backend_class : Cable::BackendCore.class = Cable::RedisBackend, example: "Cable::RedisBackend"
-    setting redis_ping_interval : Time::Span = 15.seconds
+    setting backend_class : Cable::BackendCore.class = Cable::BackendRegistry, example: "Cable::RedisBackend"
+    setting backend_ping_interval : Time::Span = 15.seconds
     setting restart_error_allowance : Int32 = 20
     setting on_error : Proc(Exception, String, Nil) = ->(exception : Exception, message : String) do
       Cable::Logger.error(exception: exception) { message }

--- a/src/cable/backend_pinger.cr
+++ b/src/cable/backend_pinger.cr
@@ -1,16 +1,16 @@
 require "tasker"
 
 module Cable
-  class RedisPinger
+  class BackendPinger
     private getter task : Tasker::Task
 
     def initialize(@server : Cable::Server)
-      @task = Tasker.every(Cable.settings.redis_ping_interval) do
-        @server.backend.ping_redis_subscribe
-        @server.backend.ping_redis_publish
+      @task = Tasker.every(Cable.settings.backend_ping_interval) do
+        @server.backend.ping_subscribe_connection
+        @server.backend.ping_publish_connection
       rescue e
         stop
-        Cable::Logger.error { "Cable::RedisPinger Exception: #{e.class.name} -> #{e.message}" }
+        Cable::Logger.error { "Cable::BackendPinger Exception: #{e.class.name} -> #{e.message}" }
         # Restart cable if something happened
         Cable.server.count_error!
         Cable.restart if Cable.server.restart?

--- a/src/cable/channel.cr
+++ b/src/cable/channel.cr
@@ -1,7 +1,5 @@
 module Cable
   class Channel
-    class CloseRedisFiber < Exception; end
-
     CHANNELS = {} of String => Cable::Channel.class
 
     macro inherited

--- a/src/cable/server.cr
+++ b/src/cable/server.cr
@@ -27,8 +27,8 @@ module Cable
     getter connections = {} of String => Cable::Connection
     getter errors = 0
     getter fiber_channel = ::Channel({String, String}).new
-    getter pinger : Cable::RedisPinger do
-      Cable::RedisPinger.new(self)
+    getter pinger : Cable::BackendPinger do
+      Cable::BackendPinger.new(self)
     end
     getter backend : Cable::BackendCore do
       Cable.settings.backend_class.new
@@ -112,7 +112,7 @@ module Cable
       end
     end
 
-    # redis only accepts strings, so we should be strict here
+    # Some backends only accept strings, so we should be strict here
     def publish(channel : String, message : String)
       backend.publish_message(channel, message)
     end
@@ -169,7 +169,7 @@ module Cable
         backend.close_publish_connection
       rescue e : IO::Error
         # the @writer IO is closed already
-        Cable::Logger.debug { "Cable::Server#shutdown Connection to redis was severed: #{e.message}" }
+        Cable::Logger.debug { "Cable::Server#shutdown Connection to backend was severed: #{e.message}" }
       end
       pinger.stop
       connections.each do |_k, v|


### PR DESCRIPTION
Ref #88

This pulls in some code from https://github.com/cable-cr/cable/pull/79

This is a big breaking change:

* `redis_ping_interval` is renamed to `backend_ping_interval`
* `ping_redis_subscribe` is renamed to `ping_subscribe_connection`
* `ping_redis_publish` is renamed to `ping_publish_connection`
* `Cable::RedisPinger` is renamed to `Cable::BackendPinger`
* Using `ENV["REDIS_URL"]` is now `ENV["CABLE_BACKEND_URL"]`
* `CloseRedisFiber` didn't seem to be used anywhere so it was removed
* Backends now need to be registered with `register "scheme"`
* `redis` is no longer required out of the box

The next few PRs will be removing the redis backend completely and moving it to a separate shard. I'll be making 2 different redis backend shards to allow using either shard without conflicts.

cc. @jgaskins 